### PR TITLE
Small bugfix and suggestion to spm_make_standalone with defined Matlab toolboxes

### DIFF
--- a/config/spm_make_standalone.m
+++ b/config/spm_make_standalone.m
@@ -116,7 +116,7 @@ end
 for i=1:numel(tbxs)
     d = fullfile(spm('Dir'),'external','fieldtrip','external',tbxs{i});
     if exist(d,'dir')
-        [sts, msg] = rmdir(d{i},'s');
+        [sts, msg] = rmdir(d,'s');
     end
 end
 

--- a/config/spm_make_standalone.m
+++ b/config/spm_make_standalone.m
@@ -41,10 +41,10 @@ end
 
 %-Input arguments
 %--------------------------------------------------------------------------
-if ~nargin
+if ~nargin || isempty(outdir)
     outdir = fullfile(spm('Dir'),'..','standalone'); 
-    if ~exist(outdir,'dir'), mkdir(outdir); end
 end
+if ~exist(outdir,'dir'), mkdir(outdir); end
 if nargin < 2 || isempty(gateway), gateway = 'spm_standalone.m'; end
 if nargin < 3, contentsver = ''; end
 if nargin < 4, tbxs = {'signal'}; end


### PR DESCRIPTION
- the brace indexing for deletion of Matlab toolbox folders within fieldtrip (argument `tbxs`) seems erroneous
- suggestion that if later input arguments are specified (e.g., `tbxs`), definition of a default `outdir` and automatic creation of a specified `outdir` parameter are convenient