### PR TITLE
Fix menu windows 11

### DIFF
--- a/spm_Menu.m
+++ b/spm_Menu.m
@@ -108,8 +108,11 @@ if ispc && strcmpi(spm_check_version,'matlab')
     try
         %M   = getframe(Fmenu);
         %col = double(M.cdata(floor(size(M.cdata,1)/3),floor(size(M.cdata,2)/2),:));
-        col = [204 204 204];
-        set(findobj(Fmenu,'UserData','LABEL'),'BackgroundColor',col/255);
+        panelcol  = [204 204 204]/255;
+        buttoncol = [220 220 220]/255;
+        set(findobj(Fmenu,'Style','pushbutton'),'BackgroundColor',buttoncol);
+        set(findobj(Fmenu,'UserData','LABEL'),'BackgroundColor',panelcol);
+        set(findobj(Fmenu,'Style','pushbutton','Enable','off','Callback',[]),'BackgroundColor',panelcol);
     end
 elseif ismac
     set(findobj(Fmenu,'UserData','LABEL'),'Visible','off','Tag','');

--- a/spm_Menu.m
+++ b/spm_Menu.m
@@ -108,11 +108,16 @@ if ispc && strcmpi(spm_check_version,'matlab')
     try
         %M   = getframe(Fmenu);
         %col = double(M.cdata(floor(size(M.cdata,1)/3),floor(size(M.cdata,2)/2),:));
-        panelcol  = [204 204 204]/255;
-        buttoncol = [220 220 220]/255;
-        set(findobj(Fmenu,'Style','pushbutton'),'BackgroundColor',buttoncol);
-        set(findobj(Fmenu,'UserData','LABEL'),'BackgroundColor',panelcol);
-        set(findobj(Fmenu,'Style','pushbutton','Enable','off','Callback',[]),'BackgroundColor',panelcol);
+        if (contains(system_dependent('getos'),'Windows 11'))
+            panelcol  = [204 204 204]/255;
+            buttoncol = [220 220 220]/255;
+            set(findobj(Fmenu,'Style','pushbutton'),'BackgroundColor',buttoncol);
+            set(findobj(Fmenu,'UserData','LABEL'),'BackgroundColor',panelcol);
+            set(findobj(Fmenu,'Style','pushbutton','Enable','off','Callback',[]),'BackgroundColor',panelcol);
+        else
+            col = [204 204 204];
+            set(findobj(Fmenu,'UserData','LABEL'),'BackgroundColor',col/255);
+        end
     end
 elseif ismac
     set(findobj(Fmenu,'UserData','LABEL'),'Visible','off','Tag','');


### PR DESCRIPTION
Under Windows 11 the colours of the spm_menu were incorrect, due to the new button style. The code implements a simple fix that renders the labels and panel backgrounds the same colour and changes the button colour to a darker grey. Alternatively, removing lines 112 and 113 renders the window using the default button style (which seems a bit ugly to me, but does retain the hover behaviour). I've tested this across all modalities on Windows 11 and it seems to work fine. I have included a switch to check for Windows 11, but this may be unnecessary if the fix works fine on Windows 10 as well. The effect before and after is shown below.

![spm_menu-before](https://user-images.githubusercontent.com/3811059/183615680-c14c1171-9603-4945-a917-809618fde351.jpg)

![spm_menu-after](https://user-images.githubusercontent.com/3811059/183615694-a0ce0c2a-c604-481e-ae21-a0f6e19e45bc.jpg)