### PR TITLE
Maintenance: dx.doi.org → doi.org

### DIFF
--- a/man/biblio/methods_group.bib
+++ b/man/biblio/methods_group.bib
@@ -940,7 +940,7 @@
   number    = 1,
   pages     = {95--113},
   year      = {2007},
-  doi       = {http://dx.doi.org/10.1016/j.neuroimage.2007.07.007},
+  doi       = {https://doi.org/10.1016/j.neuroimage.2007.07.007},
   keyword   = {spatial,registration,normalisation,MRI},
 }
 

--- a/spm_templates.md
+++ b/spm_templates.md
@@ -350,7 +350,7 @@ The following papers should be cited when using the atlas:
 >  Unbiased nonlinear average age-appropriate brain templates from birth
 >  to adulthood,  NeuroImage, Volume 47, Supplement 1, July 2009, Page
 >  S102 Organization for Human Brain Mapping 2009 Annual Meeting,
->  DOI: http://dx.doi.org/10.1016/S1053-8119809970884-5 
+>  DOI: https://doi.org/10.1016/S1053-8119809970884-5 
 
 ## /TOOLBOX/OLDNORM/ DIRECTORY
 


### PR DESCRIPTION
A proper DOI link starts with `https://doi.org`, see https://www.doi.org/:
> DOIs include a prefix (prefixes always start with `10.`) and a suffix, separated by a forward slash (`/`). Prefacing the DOI with `doi.org/` will turn it into an actionable link, for example, [**https://doi.org/10.47366/sabia.v5n1a3**](http://doi.org/10.47366/sabia.v5n1a3). Clicking that link will ‘resolve’ it, i.e. redirect to the latest information about the object it identifies, even if the object changes or moves.