### PR TITLE
Fix 40 typos found by codespell

### DIFF
--- a/@nifti/private/nifti_stats.c
+++ b/@nifti/private/nifti_stats.c
@@ -4895,7 +4895,7 @@ static void cumbet(double *x,double *y,double *a,double *b,double *cum,
 
                                    References
 
-     Didonato, Armido R. and Morris, Alfred H. Jr. (1992) Algorithim
+     Didonato, Armido R. and Morris, Alfred H. Jr. (1992) Algorithm
      708 Significant Digit Computation of the Incomplete Beta Function
      Ratios. ACM ToMS, Vol.18, No. 3, Sept. 1992, 360-373.
 

--- a/external/ctf/addCTFtrial.m
+++ b/external/ctf/addCTFtrial.m
@@ -1221,7 +1221,7 @@ function x=getArrayField(S,yfield)
 %    1. size(S(n).yfield) is the same for all n.  Any size allowed.
 %    2. S(n).yfield is a 2-D array for all structure elements S(n).
 %      Then yfield of different array elements S(n) can have different sizes.
-%      The array returned will be large enough to accomodate all of the data.
+%      The array returned will be large enough to accommodate all of the data.
 
 sizeS=size(S);
 nS=prod(sizeS);

--- a/external/ctf/getCTFBalanceCoefs.m
+++ b/external/ctf/getCTFBalanceCoefs.m
@@ -44,7 +44,7 @@ function [alphaMEG,MEGindex,MEGbalanceindex,alphaGref,Grefindex,Gbalanceindex]=.
 %            MEGbalanceindex=[], alphaGref=zeros(0,nGef), Grefindex=list of Gref channels
 %            and Gbalanceindex=[];
 
-%   alphaGref,Grefindex,Gbalanceindex : Reference-gradiometer balancing coeficients.
+%   alphaGref,Grefindex,Gbalanceindex : Reference-gradiometer balancing coefficients.
 %            These output arrays are optional.  If the calling statement includes
 %            them, then this program extracts a table of balance coefficients for
 %            the reference gradiometers from the G1BR table in the coefficient files.
@@ -255,7 +255,7 @@ function [betaMEG,MEGindex,Refindex,betaGref,Grefindex,Gbalanceindex]=...
 %            betaMEG=zeros(1,nMEG),Refindex=3 and nRef=1;
 
 
-%   betaGref,Grefindex,Gbalanceindex : Reference-gradiometer balancing coeficients.
+%   betaGref,Grefindex,Gbalanceindex : Reference-gradiometer balancing coefficients.
 %            These output arrays are optional.  If the calling statement includes
 %            them, then this program extracts a table of balance coefficients for
 %            the reference gradiometers from the G1BR table in the coefficient files.

--- a/external/ctf/writeCTFds.m
+++ b/external/ctf/writeCTFds.m
@@ -1663,7 +1663,7 @@ function x=getArrayField(S,yfield)
 %    1. size(S(n).yfield) is the same for all n.  Any size allowed.
 %    2. S(n).yfield is a 2-D array for all structure elements S(n).
 %      Then yfield of different array elements S(n) can have different sizes.
-%      The array returned will be large enough to accomodate all of the data.
+%      The array returned will be large enough to accommodate all of the data.
 
 sizeS=size(S);
 nS=prod(sizeS);

--- a/external/fieldtrip/Contents.m
+++ b/external/fieldtrip/Contents.m
@@ -57,7 +57,7 @@
 % can depend on other functions. The release of this toolbox includes functions from
 % other toolboxes that are covered under their respective licenses. See
 % fieldtrip/external for details. Unauthorised copying and distribution of functions
-% that are not explicitely covered by the GPL is not allowed!
+% that are not explicitly covered by the GPL is not allowed!
 %
 % Below is a non-exhaustive overview of some of the important FieldTrip functions, sorted by category.
 % You can get more details on a function by typing 'help functionname' in MATLAB.

--- a/external/fieldtrip/besa2fieldtrip.m
+++ b/external/fieldtrip/besa2fieldtrip.m
@@ -385,7 +385,7 @@ if iscell(labels) && length(labels)>1
 elseif iscell(labels) && length(labels)==1
   % could be a cell with a single long string in it
   if length(tokenize(labels{1}, ' '))>1
-    % seems like a long string that accidentaly ended up in a single
+    % seems like a long string that accidentally ended up in a single
     cell
     newlabels = tokenize(labels{1}, ' ');
   else

--- a/external/fieldtrip/fileio/ft_read_event.m
+++ b/external/fieldtrip/fileio/ft_read_event.m
@@ -32,7 +32,7 @@ function [event] = ft_read_event(filename, varargin)
 %
 % You can specify optional arguments as key-value pairs for filtering the events,
 % e.g. to select only events of a specific type, of a specific value, or events
-% between a specific begin and end sample. This event filtering is especially usefull
+% between a specific begin and end sample. This event filtering is especially useful
 % for real-time processing. See FT_FILTER_EVENT for more details.
 %
 % Some data formats have trigger channels that are sampled continuously with the same
@@ -565,7 +565,7 @@ switch eventformat
     end
 
     try
-      % read the trigger codes from the STIM channel, usefull for (pseudo) continuous data
+      % read the trigger codes from the STIM channel, useful for (pseudo) continuous data
       % this splits the trigger channel into the lowers and highest 16 bits,
       % corresponding with the front and back panel of the electronics cabinet at the Donders Centre
       [backpanel, frontpanel] = read_ctf_trigger(filename);

--- a/external/fieldtrip/fileio/ft_write_cifti.m
+++ b/external/fieldtrip/fileio/ft_write_cifti.m
@@ -30,7 +30,7 @@ function ft_write_cifti(filename, source, varargin)
 %   'debug'            = boolean, write a debug.xml file (default = false)
 %
 % The brainstructure refers to the global anatomical structure, such as CortexLeft, Thalamus, etc.
-% The parcellation refers to the the detailled parcellation, such as BA1, BA2, BA3, etc.
+% The parcellation refers to the the detailed parcellation, such as BA1, BA2, BA3, etc.
 %
 % See also FT_READ_CIFTI, FT_READ_MRI, FT_WRITE_MRI
 

--- a/external/fieldtrip/fileio/private/dicom2transform.m
+++ b/external/fieldtrip/fileio/private/dicom2transform.m
@@ -19,7 +19,7 @@ function M = dicom2transform(dcmheader)
 % The output argument M is a 4x4 homogenous transformation matrix that maps voxel
 % indices onto PCS world coordinates in millimeter.
 %
-% Here are some usefull DICOM references
+% Here are some useful DICOM references
 %   https://doi.org/10.1016/j.jneumeth.2016.03.001
 %   https://dicom.innolitics.com/ciods/mr-image/image-plane/00200032
 %   https://horosproject.org

--- a/external/fieldtrip/fileio/private/read_besa_besa.m
+++ b/external/fieldtrip/fileio/private/read_besa_besa.m
@@ -513,7 +513,7 @@ while ~isempty(ab_idx)
     last_outbuffer_idx = last_outbuffer_idx+n_vals;
     last_ab_idx = ab_idx+n_skip;
   else
-    % not an alowed announcing byte value
+    % not an allowed announcing byte value
     fclose(fid);
     ft_error('ReadBesaMatlab:ErrorABOutOfRange','Announcing byte out of range: %d',inbuffer(ab_idx));
   end

--- a/external/fieldtrip/fileio/private/read_biosemi_bdf.m
+++ b/external/fieldtrip/fileio/private/read_biosemi_bdf.m
@@ -15,7 +15,7 @@ function dat = read_biosemi_bdf(filename, hdr, begsample, endsample, chanindx)
 %   hdr.nSamplesPre  number of pre-trigger samples in each trial
 %   hdr.nTrials      number of trials
 %   hdr.label        cell-array with labels of each channel
-%   hdr.orig         detailled EDF header information
+%   hdr.orig         detailed EDF header information
 %
 % Or use as
 %   [dat] = read_biosemi_bdf(filename, hdr, begsample, endsample, chanindx);
@@ -155,7 +155,7 @@ if nargin==1
   EDF.Cal(tmp) = ones(size(tmp));
   EDF.Off(tmp) = zeros(size(tmp));
 
-  % the following adresses https://github.com/fieldtrip/fieldtrip/pull/395
+  % the following addresses https://github.com/fieldtrip/fieldtrip/pull/395
   tmp = find(strcmpi(cellstr(EDF.Label), 'STATUS'));
   if EDF.Cal(tmp)~=1
     timeout = 60*15; % do not show it for the next 15 minutes

--- a/external/fieldtrip/fileio/private/read_bti_m4d.m
+++ b/external/fieldtrip/fileio/private/read_bti_m4d.m
@@ -137,7 +137,7 @@ while ischar(line)
   % remove spaces from the begin and end of the string
   val = strtrim(val);
 
-  % try to convert the value string into something more usefull
+  % try to convert the value string into something more useful
   if ~iscell(val)
     % the value can contain a variety of elements, only some of which are decoded here
     if ~isempty(strfind(key, 'Index')) || ~isempty(strfind(key, 'Count')) || any(strcmp(key, numlist))

--- a/external/fieldtrip/fileio/private/read_ctf_hc.m
+++ b/external/fieldtrip/fileio/private/read_ctf_hc.m
@@ -52,7 +52,7 @@ function [hc] = read_ctf_hc(filename)
 %
 % $Id$
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 hc.standard.nas = [0 0 0];

--- a/external/fieldtrip/fileio/private/read_ctf_meg4.m
+++ b/external/fieldtrip/fileio/private/read_ctf_meg4.m
@@ -45,7 +45,7 @@ function [meg] = read_ctf_meg4(fname, hdr, begsample, endsample, chanindx)
 %
 % $Id$
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 nsmp = hdr.nSamples;

--- a/external/fieldtrip/fileio/private/read_ctf_mri.m
+++ b/external/fieldtrip/fileio/private/read_ctf_mri.m
@@ -103,7 +103,7 @@ hdr.transformMatrix = fread(fid,[4 4],'float')'; % transformation matrix head->M
 % the header (position 1028), but it seems some versions of Matlab (or
 % perhaps only on some systems) doesn't read 2 bytes somewhere and end up
 % in position 1026...  In any case, it caused an error with some files so
-% we must explicitely seek to position 1028.
+% we must explicitly seek to position 1028.
 fseek(fid, 1028, 'bof');
 
 % turn all warnings back on

--- a/external/fieldtrip/fileio/private/read_ctf_trigger.m
+++ b/external/fieldtrip/fileio/private/read_ctf_trigger.m
@@ -41,7 +41,7 @@ headerfile = fullfile(dataset, [file '.res4']);
 % read the header from the raw CTF data
 hdr = read_ctf_res4(headerfile);
 
-% number of samples to shift the assesment of the trigger value
+% number of samples to shift the assessment of the trigger value
 % this is needed because it takes some time for the rising flank to get to the correct value
 trigshift = fix(hdr.Fs * 9/1200);
 

--- a/external/fieldtrip/fileio/private/read_edf.m
+++ b/external/fieldtrip/fileio/private/read_edf.m
@@ -28,7 +28,7 @@ function [dat] = read_edf(filename, hdr, begsample, endsample, chanindx)
 %   hdr.nSamplesPre  number of pre-trigger samples in each trial
 %   hdr.nTrials      number of trials
 %   hdr.label        cell-array with labels of each channel
-%   hdr.orig         detailled EDF header information
+%   hdr.orig         detailed EDF header information
 %
 % Or use as
 %   [dat] = read_edf(filename, hdr, begsample, endsample, chanindx)

--- a/external/fieldtrip/fileio/private/read_itab_mhd.m
+++ b/external/fieldtrip/fileio/private/read_itab_mhd.m
@@ -189,7 +189,7 @@ mhd.nasion_vertex_inion = fread(fid, [1 1], 'float');
 
 %  Data analysis INFOs
 mhd.security  = fread(fid, [1 1], 'int32');          %  security flag
-mhd.ave_alignement  = fread(fid, [1 1], 'int32');    %  average data alignement 0 - FALSE
+mhd.ave_alignement  = fread(fid, [1 1], 'int32');    %  average data alignment 0 - FALSE
 %                          1 - TRUE
 
 mhd.itri  = fread(fid, [1 1], 'int32');              %  trigger channel number

--- a/external/fieldtrip/fileio/private/read_neuralynx_dma.m
+++ b/external/fieldtrip/fileio/private/read_neuralynx_dma.m
@@ -73,7 +73,7 @@ else
 end
 
 if hdroffset
-  % read the ascii header from the file, it does not contain much usefull information
+  % read the ascii header from the file, it does not contain much useful information
   orig = neuralynx_getheader(filename);
 end
 
@@ -179,7 +179,7 @@ if needhdr
   % these have to be hardcoded, since the DMA logfile does not contain header information
   hdr              = [];
   if hdroffset
-    % remember the ascii header from the file, it does not contain much usefull information
+    % remember the ascii header from the file, it does not contain much useful information
     hdr.orig       = orig;
   end
   hdr.Fs           = 32556;                   % sampling frequency

--- a/external/fieldtrip/fileio/private/read_neuromag_eve.m
+++ b/external/fieldtrip/fileio/private/read_neuromag_eve.m
@@ -13,7 +13,7 @@ function [col1, col2, col3, col4] = read_neuromag_eve(filename)
 %
 % The recording of the data to disk may start later than the actual data
 % acquisition. This is represented in hdr.orig.raw.first_samp. This potential
-% offset needs to be taken into acocunt when combining it with the data from the
+% offset needs to be taken into account when combining it with the data from the
 % file on disk.
 
 % Copyright (C) 2013, Robert Oostenveld

--- a/external/fieldtrip/fileio/private/read_plexon_ddt.m
+++ b/external/fieldtrip/fileio/private/read_plexon_ddt.m
@@ -130,7 +130,7 @@ elseif Version==102
   end
 elseif Version==103
   % I am not sure whether the calibration like this is correct, since the
-  % Plexon documentation does not explicitely specify how to do it for the
+  % Plexon documentation does not explicitly specify how to do it for the
   % 104 file format. I presume that it is identical to the 103 format.
   for i=1:dat.NChannels
     dat.data(i,:) = dat.data(i,:) * 5000 ./ (0.5 * (2^dat.BitsPerSample) * dat.ChannelGain(i));

--- a/external/fieldtrip/fileio/private/read_ricoh_data.m
+++ b/external/fieldtrip/fileio/private/read_ricoh_data.m
@@ -59,7 +59,7 @@ end
 dat = dat(chanindx,:);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_ricoh_event.m
+++ b/external/fieldtrip/fileio/private/read_ricoh_event.m
@@ -98,7 +98,7 @@ if isempty(event)
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_yokogawa_data.m
+++ b/external/fieldtrip/fileio/private/read_yokogawa_data.m
@@ -247,7 +247,7 @@ end
 dat = dat(chanindx,:);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_yokogawa_data_new.m
+++ b/external/fieldtrip/fileio/private/read_yokogawa_data_new.m
@@ -100,7 +100,7 @@ end
 dat = dat(chanindx,:);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_yokogawa_event.m
+++ b/external/fieldtrip/fileio/private/read_yokogawa_event.m
@@ -152,7 +152,7 @@ if isempty(event)
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_yokogawa_header.m
+++ b/external/fieldtrip/fileio/private/read_yokogawa_header.m
@@ -175,7 +175,7 @@ for i=1:hdr.nChans
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/read_yokogawa_header_new.m
+++ b/external/fieldtrip/fileio/private/read_yokogawa_header_new.m
@@ -192,7 +192,7 @@ for i=1:hdr.nChans
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output                          = [];

--- a/external/fieldtrip/fileio/private/ricoh2grad.m
+++ b/external/fieldtrip/fileio/private/ricoh2grad.m
@@ -143,7 +143,7 @@ grad.unit = 'cm';
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/fileio/private/write_edf.m
+++ b/external/fieldtrip/fileio/private/write_edf.m
@@ -95,7 +95,7 @@ physMin{4} = sprintf('%-8.4g', double(minV) ./ scale);
 physMin{5} = sprintf('%-8.3g', double(minV) ./ scale);
 physMin{6} = sprintf('%-8.2g', double(minV) ./ scale);
 physMin{7} = sprintf('%-8.1g', double(minV) ./ scale);
-% take the first (most detailled) one that fits within the character space
+% take the first (most detailed) one that fits within the character space
 physMin = physMin{find(cellfun(@length, physMin)==nChans*8, 1, 'first')};
 
 physMax{1} = sprintf('%-8.7g', double(maxV) ./ scale);
@@ -105,7 +105,7 @@ physMax{4} = sprintf('%-8.4g', double(maxV) ./ scale);
 physMax{5} = sprintf('%-8.3g', double(maxV) ./ scale);
 physMax{6} = sprintf('%-8.2g', double(maxV) ./ scale);
 physMax{7} = sprintf('%-8.1g', double(maxV) ./ scale);
-% take the first (most detailled) one that fits within the character space
+% take the first (most detailed) one that fits within the character space
 physMax = physMax{find(cellfun(@length, physMax)==nChans*8, 1, 'first')};
 
 fid = fopen_or_error(filename, 'wb', 'ieee-le');

--- a/external/fieldtrip/fileio/private/yokogawa2grad.m
+++ b/external/fieldtrip/fileio/private/yokogawa2grad.m
@@ -130,7 +130,7 @@ grad.unit = 'cm';
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output                          = [];

--- a/external/fieldtrip/fileio/private/yokogawa2grad_new.m
+++ b/external/fieldtrip/fileio/private/yokogawa2grad_new.m
@@ -194,7 +194,7 @@ grad.unit = 'cm';
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% this defines some usefull constants
+% this defines some useful constants
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function handles = definehandles
 handles.output = [];

--- a/external/fieldtrip/forward/private/mesh2edge.m
+++ b/external/fieldtrip/forward/private/mesh2edge.m
@@ -62,21 +62,21 @@ end % isfield(mesh)
 % keep the original as "edge" and the sorted one as "sedge"
 sedge = sort(edge, 2);
 
-% % find the edges that are not shared -> count the number of occurences
+% % find the edges that are not shared -> count the number of occurrences
 % n = size(sedge,1);
-% occurences = ones(n,1);
+% occurrences = ones(n,1);
 % for i=1:n
 %   for j=(i+1):n
 %     if all(sedge(i,:)==sedge(j,:))
-%       occurences(i) = occurences(i)+1;
-%       occurences(j) = occurences(j)+1;
+%       occurrences(i) = occurrences(i)+1;
+%       occurrences(j) = occurrences(j)+1;
 %     end
 %   end
 % end
 %
 % % make the selection in the original, not the sorted version of the edges
 % % otherwise the orientation of the edges might get flipped
-% edge = edge(occurences==1,:);
+% edge = edge(occurrences==1,:);
 
 % find the edges that are not shared
 indx = findsingleoccurringrows(sedge);

--- a/external/fieldtrip/forward/private/retriangulate.m
+++ b/external/fieldtrip/forward/private/retriangulate.m
@@ -27,7 +27,7 @@ function [pnt3, tri3] = retriangulate(pnt1, tri1, pnt2, tri2, flag)
 
 % Copyright (C) 2003-2013, Robert Oostenveld
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 if nargin<5

--- a/external/fieldtrip/ft_analysispipeline.m
+++ b/external/fieldtrip/ft_analysispipeline.m
@@ -200,7 +200,7 @@ end
 pipeline = tmp;
 
 if istrue(cfg.prune)
-  % prune the double occurences
+  % prune the double occurrences
   [dummy, indx] = unique({pipeline.this});
   pipeline = pipeline(sort(indx));
 end

--- a/external/fieldtrip/ft_appendspike.m
+++ b/external/fieldtrip/ft_appendspike.m
@@ -127,7 +127,7 @@ else
 
     % determine the corresponding sample numbers for each timestamp
     ts = spike.timestamp{i};
-    % timestamps can be uint64, hence explicitely convert to double at the
+    % timestamps can be uint64, hence explicitly convert to double at the
     % right moment
     if strcmp(class(ts),class(FirstTimeStamp))
       sample = round(double(ts-FirstTimeStamp)/TimeStampPerSample + 1);

--- a/external/fieldtrip/ft_channelrepair.m
+++ b/external/fieldtrip/ft_channelrepair.m
@@ -177,7 +177,7 @@ if needsens
   ismeg  = ft_senstype(sens, 'meg');
   isnirs = ft_senstype(sens, 'opto');
   
-  % determine the detailled type, e.g. ctf151 or neuromag122
+  % determine the detailed type, e.g. ctf151 or neuromag122
   sensortype = ft_senstype(sens);
   
 else
@@ -185,7 +185,7 @@ else
   iseeg  = ft_senstype(data, 'eeg');
   ismeg  = ft_senstype(data, 'meg');
   isnirs = ft_senstype(data, 'opto');
-  % determine the detailled type, e.g. ctf151 or neuromag122
+  % determine the detailed type, e.g. ctf151 or neuromag122
   sensortype = ft_senstype(data);
 end
 
@@ -480,7 +480,7 @@ end
 ft_postamble debug
 ft_postamble previous data
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = interp;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_databrowser.m
+++ b/external/fieldtrip/ft_databrowser.m
@@ -15,7 +15,7 @@ function [cfg] = ft_databrowser(cfg, data)
 %
 % If you want to browse data that is on disk, you have to specify
 %   cfg.dataset                 = string with the filename
-% Instead of specifying the dataset, you can also explicitely specify the name of the
+% Instead of specifying the dataset, you can also explicitly specify the name of the
 % file containing the header information and the name of the file containing the
 % data, using
 %   cfg.datafile                = string with the filename
@@ -1974,7 +1974,7 @@ if strcmp(cfg.plotartifacts, 'yes')
     end
 
     for k=1:numel(artbeg)
-      i = i + 1; % it is not a simple loop, there are multiple types of artifacts, times multiple occurences
+      i = i + 1; % it is not a simple loop, there are multiple types of artifacts, times multiple occurrences
       artifacttime(i) = tim(artbeg(k)) + opt.hlim(1);
       xpos = [tim(artbeg(k)) tim(artend(k))];
 

--- a/external/fieldtrip/ft_dipolefitting.m
+++ b/external/fieldtrip/ft_dipolefitting.m
@@ -349,7 +349,7 @@ if numel(cfg.dip.pos)~=cfg.numdipoles*3 || numel(cfg.dip.mom)~=cfg.numdipoles*3
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% perform the dipole scan, this is usefull for generating an initial guess
+% perform the dipole scan, this is useful for generating an initial guess
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if strcmp(cfg.gridsearch, 'yes')
   % test whether we have a valid configuration for dipole scanning

--- a/external/fieldtrip/ft_electrodeplacement.m
+++ b/external/fieldtrip/ft_electrodeplacement.m
@@ -79,7 +79,7 @@ function [elec] = ft_electrodeplacement(cfg, varargin)
 %   cfg.fiducial.ini   = 1x3 vector with coordinates
 %   cfg.fiducial.lpa   = 1x3 vector with coordinates
 %   cfg.fiducial.rpa   = 1x3 vector with coordinates
-%   cfg.feedback       = string, can be 'yes' or 'no' for detailled feedback (default = 'yes')
+%   cfg.feedback       = string, can be 'yes' or 'no' for detailed feedback (default = 'yes')
 %
 % The following options apply to the 'shaft' method
 %   cfg.shaft.tip      = 1x3 position of the electrode at the tip of the shaft
@@ -1604,7 +1604,7 @@ elseif strcmp(opt.method, 'headshape')
     delete(findobj(h,'Type', 'Line', 'Marker', '+', 'Color', [0 0 0])) % remove previous crosshairs
     hold on; plot3(opt.pos(:,1), opt.pos(:,2), opt.pos(:,3), 'marker', '+', 'linestyle', 'none', 'color', [0 0 0], 'MarkerSize', 12); % plot the crosshair
   end
-  %opt.pos = ft_select_point3d(opt.headshape, 'nearest', true, 'multiple', false, 'marker', '+'); % FIXME: this gets stuck in a loop waiting for any abritrary buttonpress
+  %opt.pos = ft_select_point3d(opt.headshape, 'nearest', true, 'multiple', false, 'marker', '+'); % FIXME: this gets stuck in a loop waiting for any arbitrary buttonpress
 end
 setappdata(h, 'opt', opt);
 

--- a/external/fieldtrip/ft_freqbaseline.m
+++ b/external/fieldtrip/ft_freqbaseline.m
@@ -160,7 +160,7 @@ end
 ft_postamble debug
 ft_postamble previous   freq
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 freq = freqOut;
 
 ft_postamble provenance freq

--- a/external/fieldtrip/ft_freqdescriptives.m
+++ b/external/fieldtrip/ft_freqdescriptives.m
@@ -215,7 +215,7 @@ end
 ft_postamble debug
 ft_postamble previous freq
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 freq = output;
 
 ft_postamble provenance freq

--- a/external/fieldtrip/ft_freqsimulation.m
+++ b/external/fieldtrip/ft_freqsimulation.m
@@ -31,7 +31,7 @@ function [data] = ft_freqsimulation(cfg)
 %
 % For each of the methods default parameters are configured to generate
 % example data, including noise. To get full control over the generated
-% data you should explicitely set all parameters involved in the method
+% data you should explicitly set all parameters involved in the method
 % of your choise. The interpretation of the following signal components
 % depends on the specified method:
 %

--- a/external/fieldtrip/ft_headmovement.m
+++ b/external/fieldtrip/ft_headmovement.m
@@ -50,7 +50,7 @@ function [varargout] = ft_headmovement(cfg)
 % If cfg.method = 'pertrial_clusters', the cell-array of output structures
 % contains sets of trials where the trial-specific head position was
 % considered to be positioned close to the corresponding kmeans-cluster's
-% centroid. The corresponding grad-structure is specified accordin to the
+% centroid. The corresponding grad-structure is specified according to the
 % cluster's centroid. This method requires cfg.numclusters to be specified.
 %
 % The updatesens method and related methods are described by Stolk et al., Online and

--- a/external/fieldtrip/ft_layoutplot.m
+++ b/external/fieldtrip/ft_layoutplot.m
@@ -29,7 +29,7 @@ function [cfg] = ft_layoutplot(cfg, data)
 %   cfg.opto        = structure with optode definition or filename, see FT_READ_SENS
 %   cfg.output      = filename to which the layout will be written (default = [])
 %   cfg.montage     = 'no' or a montage structure (default = 'no')
-%   cfg.image       = filename, use an image to construct a layout (e.g. usefull for ECoG grids)
+%   cfg.image       = filename, use an image to construct a layout (e.g. useful for ECoG grids)
 %   cfg.box         = string, 'yes' or 'no' whether box should be plotted around electrode (default = 'yes')
 %   cfg.mask        = string, 'yes' or 'no' whether the mask should be plotted (default = 'yes')
 %   cfg.visible     = string, 'on' or 'off' whether figure will be visible (default = 'on')

--- a/external/fieldtrip/ft_megplanar.m
+++ b/external/fieldtrip/ft_megplanar.m
@@ -355,7 +355,7 @@ end
 ft_postamble debug
 ft_postamble previous data
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = interp;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_megrealign.m
+++ b/external/fieldtrip/ft_megrealign.m
@@ -403,7 +403,7 @@ end
 ft_postamble debug
 ft_postamble previous data
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = interp;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_preprocessing.m
+++ b/external/fieldtrip/ft_preprocessing.m
@@ -699,7 +699,7 @@ end % if updatesens
 ft_postamble debug
 ft_postamble previous data
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = dataout;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_regressconfound.m
+++ b/external/fieldtrip/ft_regressconfound.m
@@ -311,7 +311,7 @@ end
 ft_postamble debug
 ft_postamble previous datain
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = dataout;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_rejectartifact.m
+++ b/external/fieldtrip/ft_rejectartifact.m
@@ -244,7 +244,7 @@ else
   checkCritToi = 0;
 end
 
-% prevent double occurences of artifact types, ensure that the order remains the same
+% prevent double occurrences of artifact types, ensure that the order remains the same
 [fn, i] = unique(cfg.artfctdef.type);
 cfg.artfctdef.type = cfg.artfctdef.type(sort(i));
 % ensure that it is a row vector

--- a/external/fieldtrip/ft_resampledata.m
+++ b/external/fieldtrip/ft_resampledata.m
@@ -33,7 +33,7 @@ function [data] = ft_resampledata(cfg, data)
 %
 % The methods 'resample' and 'decimate' automatically apply an anti-aliasing low-pass
 % filter. You can also explicitly specify an anti-aliasing low pass filter. This is
-% particularly adviced when downsampling using the 'downsample' method, but also when
+% particularly advised when downsampling using the 'downsample' method, but also when
 % strong noise components are present just above the new Nyquist frequency.
 %   cfg.lpfilter    = 'yes' or 'no' (default = 'no')
 %   cfg.lpfreq      = scalar value for low pass frequency (there is no default, so needs to be always specified)

--- a/external/fieldtrip/ft_scalpcurrentdensity.m
+++ b/external/fieldtrip/ft_scalpcurrentdensity.m
@@ -292,7 +292,7 @@ end
 ft_postamble debug
 ft_postamble previous data
 
-% rename the output variable to accomodate the savevar postamble
+% rename the output variable to accommodate the savevar postamble
 data = scd;
 
 ft_postamble provenance data

--- a/external/fieldtrip/ft_sourcewrite.m
+++ b/external/fieldtrip/ft_sourcewrite.m
@@ -147,7 +147,7 @@ switch (cfg.filetype)
 
   case 'cifti'
     % brainstructure should represent the global anatomical structure, such as CortexLeft, Thalamus, etc.
-    % parcellation should represent the detailled parcellation, such as BA1, BA2, BA3, etc.
+    % parcellation should represent the detailed parcellation, such as BA1, BA2, BA3, etc.
     ft_write_cifti(cfg.filename, source, 'parameter', cfg.parameter, 'brainstructure', cfg.brainstructure, 'parcellation', cfg.parcellation, 'precision', cfg.precision);
 
   otherwise

--- a/external/fieldtrip/ft_topoplotCC.m
+++ b/external/fieldtrip/ft_topoplotCC.m
@@ -17,7 +17,7 @@ function [cfg] = ft_topoplotCC(cfg, freq)
 %   cfg.position      = location and size of the figure, specified as [left bottom width height] (default is automatic)
 %   cfg.renderer      = string, 'opengl', 'zbuffer', 'painters', see RENDERERINFO (default is automatic, try 'painters' when it crashes)
 %
-% The widthparam should be indicated in pixels, e.g. usefull numbers are 1 and
+% The widthparam should be indicated in pixels, e.g. useful numbers are 1 and
 % larger.
 %
 % The alphaparam should be indicated as opacity between 0 (fully transparent)

--- a/external/fieldtrip/plotting/private/mesh2edge.m
+++ b/external/fieldtrip/plotting/private/mesh2edge.m
@@ -62,21 +62,21 @@ end % isfield(mesh)
 % keep the original as "edge" and the sorted one as "sedge"
 sedge = sort(edge, 2);
 
-% % find the edges that are not shared -> count the number of occurences
+% % find the edges that are not shared -> count the number of occurrences
 % n = size(sedge,1);
-% occurences = ones(n,1);
+% occurrences = ones(n,1);
 % for i=1:n
 %   for j=(i+1):n
 %     if all(sedge(i,:)==sedge(j,:))
-%       occurences(i) = occurences(i)+1;
-%       occurences(j) = occurences(j)+1;
+%       occurrences(i) = occurrences(i)+1;
+%       occurrences(j) = occurrences(j)+1;
 %     end
 %   end
 % end
 %
 % % make the selection in the original, not the sorted version of the edges
 % % otherwise the orientation of the edges might get flipped
-% edge = edge(occurences==1,:);
+% edge = edge(occurrences==1,:);
 
 % find the edges that are not shared
 indx = findsingleoccurringrows(sedge);

--- a/external/fieldtrip/preproc/ft_preproc_online_filter_init.m
+++ b/external/fieldtrip/preproc/ft_preproc_online_filter_init.m
@@ -76,5 +76,5 @@ M = [[0; -A(2:end); 0],[eye(state.N);zeros(2,state.N)],[B;1]];
 n = null(M-eye(2+state.N));  % = eigenvector of M corresponding to eigenvalue=1, that is n=M*n
 n = n(:,1);               % ensure that it is only the first eigenvector
 z = n(2:end-1);           % delay state part of it
-z = z*(1-B(1))/z(1);      % scale appropiately
+z = z*(1-B(1))/z(1);      % scale appropriately
 state.z = x*z';

--- a/external/fieldtrip/private/megplanar_fitplane.m
+++ b/external/fieldtrip/private/megplanar_fitplane.m
@@ -3,7 +3,7 @@ function montage = megplanar_fitplane(cfg, grad)
 % Fit a plane through the B=f(x,y) plane and compute its two gradients
 % The first point in the plane is the gradiometer itself,
 % the neighbours are the subsequent points. This method also returns the
-% offset of the B-plane at each sensor, which is appriximately equal to the
+% offset of the B-plane at each sensor, which is approximately equal to the
 % field itself.
 
 % Copyright (C) 2004-2009, Robert Oostenveld

--- a/external/fieldtrip/private/mesh2edge.m
+++ b/external/fieldtrip/private/mesh2edge.m
@@ -62,21 +62,21 @@ end % isfield(mesh)
 % keep the original as "edge" and the sorted one as "sedge"
 sedge = sort(edge, 2);
 
-% % find the edges that are not shared -> count the number of occurences
+% % find the edges that are not shared -> count the number of occurrences
 % n = size(sedge,1);
-% occurences = ones(n,1);
+% occurrences = ones(n,1);
 % for i=1:n
 %   for j=(i+1):n
 %     if all(sedge(i,:)==sedge(j,:))
-%       occurences(i) = occurences(i)+1;
-%       occurences(j) = occurences(j)+1;
+%       occurrences(i) = occurrences(i)+1;
+%       occurrences(j) = occurrences(j)+1;
 %     end
 %   end
 % end
 %
 % % make the selection in the original, not the sorted version of the edges
 % % otherwise the orientation of the edges might get flipped
-% edge = edge(occurences==1,:);
+% edge = edge(occurrences==1,:);
 
 % find the edges that are not shared
 indx = findsingleoccurringrows(sedge);

--- a/external/fieldtrip/private/prepare_design.m
+++ b/external/fieldtrip/private/prepare_design.m
@@ -63,7 +63,7 @@ function [cfg] = prepare_design(cfg)
 %
 % $Id$
 
-% determine whether a beween or a within-units design is requested.
+% determine whether a between or a within-units design is requested.
 if any(strcmp(cfg.statistic,{'indepsamplesT','indepsamplesregrT','indepsamplesZcoh','indepsamplesF'}))
     designtype = 'between';
 end

--- a/external/fieldtrip/private/prepare_mesh_segmentation.m
+++ b/external/fieldtrip/private/prepare_mesh_segmentation.m
@@ -162,10 +162,10 @@ for i=1:numel(cfg.tissue)
   % this also ensures that the mesh at the bottom of the neck will be closed
   seg = volumepad(seg);
   
-  % update the dimensions of the segmented volume to accomodate the padding
+  % update the dimensions of the segmented volume to accommodate the padding
   dim = mri.dim+2;
   
-  % update the homogenous transformation matrix to accomodate the shift that is due to the padding
+  % update the homogenous transformation matrix to accommodate the shift that is due to the padding
   transform = mri.transform;
   shift = ft_warp_apply(transform, [1 1 1]) - ft_warp_apply(transform, [0 0 0]);
   transform(1,4) = transform(1,4) - shift(1);

--- a/external/fieldtrip/private/read_ctf_hc.m
+++ b/external/fieldtrip/private/read_ctf_hc.m
@@ -52,7 +52,7 @@ function [hc] = read_ctf_hc(filename)
 %
 % $Id$
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 hc.standard.nas = [0 0 0];

--- a/external/fieldtrip/private/read_neuralynx_dma.m
+++ b/external/fieldtrip/private/read_neuralynx_dma.m
@@ -73,7 +73,7 @@ else
 end
 
 if hdroffset
-  % read the ascii header from the file, it does not contain much usefull information
+  % read the ascii header from the file, it does not contain much useful information
   orig = neuralynx_getheader(filename);
 end
 
@@ -179,7 +179,7 @@ if needhdr
   % these have to be hardcoded, since the DMA logfile does not contain header information
   hdr              = [];
   if hdroffset
-    % remember the ascii header from the file, it does not contain much usefull information
+    % remember the ascii header from the file, it does not contain much useful information
     hdr.orig       = orig;
   end
   hdr.Fs           = 32556;                   % sampling frequency

--- a/external/fieldtrip/private/resampledesign.m
+++ b/external/fieldtrip/private/resampledesign.m
@@ -185,7 +185,7 @@ if isempty(cfg.uvar) && strcmp(cfg.resampling, 'permutation')
   
 elseif isempty(cfg.uvar) && strcmp(cfg.resampling, 'bootstrap')
   % randomly draw with replacement, keeping the number of elements the same in each class
-  % only the test under the null-hypothesis (h0) is explicitely implemented here
+  % only the test under the null-hypothesis (h0) is explicitly implemented here
   % but the h1 test can be achieved using a control variable
   resample = zeros(cfg.numrandomization, Nrepl);
   for i=1:cfg.numrandomization
@@ -251,7 +251,7 @@ elseif ~isempty(cfg.uvar) && strcmp(cfg.resampling, 'permutation')
   
 elseif length(cfg.uvar)==1 && strcmp(cfg.resampling, 'bootstrap') && isempty(cfg.cvar)
   % randomly draw with replacement, keeping the number of elements the same in each class
-  % only the test under the null-hypothesis (h0) is explicitely implemented here
+  % only the test under the null-hypothesis (h0) is explicitly implemented here
   % but the h1 test can be achieved using a control variable
   
   % FIXME allow for length(cfg.uvar)>1, does it make sense in the first place

--- a/external/fieldtrip/private/retriangulate.m
+++ b/external/fieldtrip/private/retriangulate.m
@@ -27,7 +27,7 @@ function [pnt3, tri3] = retriangulate(pnt1, tri1, pnt2, tri2, flag)
 
 % Copyright (C) 2003-2013, Robert Oostenveld
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 if nargin<5

--- a/external/fieldtrip/private/spikesort.m
+++ b/external/fieldtrip/private/spikesort.m
@@ -48,7 +48,7 @@ function [numA, numB, indA, indB] = spikesort(numA, numB, varargin)
 %
 % $Id$
 
-% this can be used for printing detailled user feedback
+% this can be used for printing detailed user feedback
 fb = false;
 
 % get the options

--- a/external/fieldtrip/private/warp_fsaverage_sym.m
+++ b/external/fieldtrip/private/warp_fsaverage_sym.m
@@ -3,7 +3,7 @@ function [coord_norm] = warp_fsaverage_sym(cfg, elec)
 % WARP_FSAVERAGE_SYM maps left or right hemisphere electrodes onto 
 % FreeSurfer's fsaverage_sym's left hemisphere. To perform this mapping, 
 % you first need to have processed the subject's MRI with FreeSurfer's 
-% recon-all functionality and additionaly have registered the subject's resulting 
+% recon-all functionality and additionally have registered the subject's resulting 
 % surfaces to freesurfer fsaverage_sym template using surfreg as described 
 % in section 1.2 of https://surfer.nmr.mgh.harvard.edu/fswiki/Xhemi
 %

--- a/external/fieldtrip/src/read_16bit.c
+++ b/external/fieldtrip/src/read_16bit.c
@@ -90,7 +90,7 @@ mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
     dat_p[i] = (double)(buf[i]);
   }
 
-  /* explicitely free the buffer memory and don't wait for the garbage collector */
+  /* explicitly free the buffer memory and don't wait for the garbage collector */
   mxFree(buf);
 
   /* assign the output parameters */

--- a/external/fieldtrip/src/read_24bit.c
+++ b/external/fieldtrip/src/read_24bit.c
@@ -114,7 +114,7 @@ mexFunction (int nlhs, mxArray * plhs[], int nrhs, const mxArray * prhs[])
     dat_p[count] = ((int32_t) ((b3 << 24) | (b2 << 16) | (b1 << 8)))/256;
   }
 
-  /* explicitely free the buffer memory and don't wait for the garbage collector */
+  /* explicitly free the buffer memory and don't wait for the garbage collector */
   mxFree(buf);
   
   /* assign the output parameters */

--- a/external/fieldtrip/trialfun/ft_trialfun_twoclass_classification.m
+++ b/external/fieldtrip/trialfun/ft_trialfun_twoclass_classification.m
@@ -2,7 +2,7 @@ function [trl] = ft_trialfun_twoclass_classification(cfg)
 
 % FT_TRIALFUN_TWOCLASS_CLASSIFICATION can be used to train and test a real-time
 % classifier in offline and online mode. It selects pieces of data in the two classes
-% based on two trigger values. The first N occurences in each class are marked as
+% based on two trigger values. The first N occurrences in each class are marked as
 % training items. All subsequent occurrences are marked as test items.
 %
 % This function can be used in conjunction with FT_REALTIME_CLASSIFICATION. The

--- a/spm_dcm_peb_fit.m
+++ b/spm_dcm_peb_fit.m
@@ -22,7 +22,7 @@ function [DCM,PEB,M,HCM] = spm_dcm_peb_fit(GCM,M,field)
 %          'All' will invoke all fields (i.e. random effects)
 %
 %
-% DCM  - DCM structures inverted with emprical priors
+% DCM  - DCM structures inverted with empirical priors
 % PEB  - second level model structure
 % F    - ssecond level free energy over iterations
 % -------------------------------------------------------------

--- a/spm_dcm_peb_full.m
+++ b/spm_dcm_peb_full.m
@@ -40,7 +40,7 @@ function [PEB,P]   = spm_dcm_peb_full(P,M,field)
 %     PEB.Ce   -   expected covariance of second level random effects
 %     PEB.F    -   free energy of second level model
 %
-% DCM    - 1st level (reduced) DCM structures with emprical priors
+% DCM    - 1st level (reduced) DCM structures with empirical priors
 %
 %          If DCM is an an (N x M} array, hierarchicial inversion will be
 %          applied to each model (i.e., each row) - and PEB will be a 

--- a/spm_dcm_ppd.m
+++ b/spm_dcm_ppd.m
@@ -87,8 +87,8 @@ nX    = size(X,2);               % number of explanatory variables
 bC    = var(X(:,iX))*4;
 bC    = sparse(iX,1,bC,nX,1);    % prior covariances (variables)
 M.X   = 1;                       % no between subject effects
-M.W   = PEB.Ep;                  % emprical prior expectations
-M.pC  = PEB.Ce;                  % emprical prior covariance (parameters)
+M.W   = PEB.Ep;                  % empirical prior expectations
+M.pC  = PEB.Ce;                  % empirical prior covariance (parameters)
 M.bE  = Y; M.bE(:,iX) = 0;       % prior expectation (variables)
 M.bC  = diag(bC + 1);            % prior covariances (variables)
 

--- a/spm_eeg_invertiter.m
+++ b/spm_eeg_invertiter.m
@@ -3,7 +3,7 @@ function [Dtest,modelF,allF]=spm_eeg_invertiter(Dtest,Npatchiter,funcname,patchi
 %  pseudo-randomly selected priors- in this case single cortical patches
 %
 % Npatchiter: number of iterations
-% funcname is name of MSP alogorithm: current (spm_eeg_invert) or classic (spm_eeg_invert_classic)
+% funcname is name of MSP algorithm: current (spm_eeg_invert) or classic (spm_eeg_invert_classic)
 % patchind is an optional list of indices of vertices which will be patch
 % centres. patchind will have size Npatchiter*Np (where Np is number of patches set in
 % inverse.Np )

--- a/spm_mb_ui.m
+++ b/spm_mb_ui.m
@@ -331,7 +331,7 @@ switch lower(action)
         %                      M B  :  R E S U L T S
         %==================================================================
         
-        %-Get MB and ananlysis
+        %-Get MB and analysis
         %------------------------------------------------------------------
         MB       = varargin{1};
         analysis = varargin{2};

--- a/toolbox/DARTEL/spm_dartel_resids.m
+++ b/toolbox/DARTEL/spm_dartel_resids.m
@@ -261,7 +261,7 @@ if false
             % Eq. 6.33
             sc1(i) = g(mu,x1)*inv(F)*g(mu,x2);
 
-            % The aproach used for binomial distributions
+            % The approach used for binomial distributions
             vr     = (1-mu)*mu;
             sc2(i) = (x1-mu)*inv(vr)*(x2-mu);
         end

--- a/toolbox/DAiSS/doc/commands/03_features.md
+++ b/toolbox/DAiSS/doc/commands/03_features.md
@@ -160,7 +160,7 @@ S.cross_terms = 'megeeg'; % for just EEG sensors
 ```
 
 #### bootstrap
-Generate the matrix using a bootstap selection of trials. e.g. instead of trials `[1 2 3 4 5 6 7 8 9]` you would make a matrix out of a random subset of the trials, but keeping the total number of trials the same, such as `[1 1 1 4 5 6 7 7 9]`. 
+Generate the matrix using a bootstrap selection of trials. e.g. instead of trials `[1 2 3 4 5 6 7 8 9]` you would make a matrix out of a random subset of the trials, but keeping the total number of trials the same, such as `[1 1 1 4 5 6 7 7 9]`. 
 
 ```matlab
 

--- a/toolbox/DAiSS/doc/commands/04_inverse.md
+++ b/toolbox/DAiSS/doc/commands/04_inverse.md
@@ -185,7 +185,7 @@ S.method = 'ebb'
 S.ebb.iid = 0;
 ```
 #### corr <a name="ebb_corr"></a>
-Adds correlated source assumptions to the prior in addition to the uncorrelated source assmptions of EBB, this is the implementation of cEBB used in [O'Neill et al. (2021)](https://doi.org/10.1038/s41598-021-96933-0).
+Adds correlated source assumptions to the prior in addition to the uncorrelated source assumptions of EBB, this is the implementation of cEBB used in [O'Neill et al. (2021)](https://doi.org/10.1038/s41598-021-96933-0).
 Note: this automatically assumes the correlated sources are bilateral (i.e. mirrored along the central fissure). For a more flexible implementation of correlated sources see the [pairs](#ebb_pairs) option.
 ```matlab
 

--- a/toolbox/DAiSS/doc/commands/05_output.md
+++ b/toolbox/DAiSS/doc/commands/05_output.md
@@ -127,7 +127,7 @@ S.conditions = {'condtion_01','condition_02');
 ```
 
 #### sametrials
-Take the same trials as used for filter computation. This is useful for bootstraping.
+Take the same trials as used for filter computation. This is useful for bootstrapping.
 ```matlab
 
 % matlabbatch

--- a/toolbox/DAiSS/private/GALA_find_localmin.m
+++ b/toolbox/DAiSS/private/GALA_find_localmin.m
@@ -63,7 +63,7 @@ function regions = GALA_find_localmin(lJcov,Nl,Nd,A,thresh)
         % add boundary vertices to appropriate cluster
         
         A0=Aip-eye(length(Aip));    % direct neighbors matrix
-        for i=1:length(bound)   % loop by all boudary vertices
+        for i=1:length(bound)   % loop by all boundary vertices
             
             neib = find(A0(:,bound(i)));    % direct neighbors of current verex
 

--- a/toolbox/DEM/DEMO_DCM_PEB.m
+++ b/toolbox/DEM/DEMO_DCM_PEB.m
@@ -248,8 +248,8 @@ BMA       = spm_dcm_peb_bmc(PEB);
 
 % overlay true values
 %--------------------------------------------------------------------------
-Tp        = spm_vec(DCM.Ep);           % true second level paramters
-Tx        = spm_vec(DCM.Ex);           % true second level paramters
+Tp        = spm_vec(DCM.Ep);           % true second level parameters
+Tx        = spm_vec(DCM.Ex);           % true second level parameters
 
 subplot(3,3,1),hold on, bar(Tp(BMA.Pind),1/2), hold off
 subplot(3,3,4),hold on, bar(Tp(BMA.Pind),1/2), hold off

--- a/toolbox/DEM/DEMO_DCM_PEB_FIT.m
+++ b/toolbox/DEM/DEMO_DCM_PEB_FIT.m
@@ -10,7 +10,7 @@ function DEMO_DCM_PEB_FIT
 % Bayesian model comparison  (and averages) at the between subject level.
 %
 % This demo considers a single goup (e.g., of normal subjects) and the
-% differences between the group average using emprical Bayesian reduction
+% differences between the group average using empirical Bayesian reduction
 % and the Bayesian reduction of the (grand) average response.
 %
 % See also: DEMO_DCM_PEB_REC.m

--- a/toolbox/DEM/DEMO_DCM_PEB_REC.m
+++ b/toolbox/DEM/DEMO_DCM_PEB_REC.m
@@ -102,8 +102,8 @@ DCM.Ep.B{1} = [
 X           = [ones(Ns,1) kron([-1;1],ones(Ns/2,1)) randn(Ns,1)];
 DCM.Ex      = spm_zeros(DCM.Ep);
 DCM.Ex.B{1} = -B{mx}*2*sd;
-Tp          = spm_vec(DCM.Ep);           % true second level paramters
-Tx          = spm_vec(DCM.Ex);           % true second level paramters
+Tp          = spm_vec(DCM.Ep);           % true second level parameters
+Tx          = spm_vec(DCM.Ex);           % true second level parameters
 
 % create subject-specifc DCM
 %--------------------------------------------------------------------------

--- a/toolbox/DEM/DEMO_MDP_Stroop.m
+++ b/toolbox/DEM/DEMO_MDP_Stroop.m
@@ -491,7 +491,7 @@ Z.Ep = Ep;
 Z.Cp = Cp;
 save('Z','Z')
 
-% Repeat the above with each data-source omitted (to caculate information
+% Repeat the above with each data-source omitted (to calculate information
 % gained from each source).
 %--------------------------------------------------------------------------
 M.ch      = 0; % Omit choice data

--- a/toolbox/DEM/DEM_demo_Cornsweet.m
+++ b/toolbox/DEM/DEM_demo_Cornsweet.m
@@ -295,7 +295,7 @@ sim.Emb    = d2;              % conditional expectation of mach band effect
 sim.Vcs    = v1;              % conditional dispersion of Cornsweet effect
 sim.Vmb    = v2;              % conditional dispersion of mach band effect
  
-% add emprical contrasts that were used
+% add empirical contrasts that were used
 %--------------------------------------------------------------------------
 sim.Con_cs = cornsweet.cornsweet;
 sim.Con_mb = mach.machContrast;

--- a/toolbox/DEM/DEM_demo_hdm.m
+++ b/toolbox/DEM/DEM_demo_hdm.m
@@ -2,7 +2,7 @@ function DEM_demo_hdm
 % demo for Hemodynamic deconvolution
 %__________________________________________________________________________
 
-% load emprical data and set-up
+% load empirical data and set-up
 %==========================================================================
 load HDM
 global dt

--- a/toolbox/DEM/DEM_demo_song_priors.m
+++ b/toolbox/DEM/DEM_demo_song_priors.m
@@ -67,7 +67,7 @@ DEM      = spm_DEM_generate(M,N);
 DEM.M(1).x = [1; 1; 8];
 DEM.M(2).x = [1; 1; 8];
  
-% canoncial DEM
+% canonical DEM
 %--------------------------------------------------------------------------
 DEMc   = DEM;
  

--- a/toolbox/DEM/DEM_spatial_deconvolution.m
+++ b/toolbox/DEM/DEM_spatial_deconvolution.m
@@ -189,7 +189,7 @@ for i = 1:nD
  k    = k + D*(d.^2);
 end
 
-% cosine aproximation to Gaussian
+% cosine approximation to Gaussian
 %--------------------------------------------------------------------------
 i     = find(abs(k) < pi);
 K(i)  = (1 + cos(k(i)/pi))/2;

--- a/toolbox/DEM/spm_DEM_M.m
+++ b/toolbox/DEM/spm_DEM_M.m
@@ -47,7 +47,7 @@ switch lower(model)
 
 
     % hierarchical linear generative model - the basis for  static models
-    % These subsume: Parametric emprical Bayes (PEB) models
+    % These subsume: Parametric empirical Bayes (PEB) models
     %                Mixed effects (MFX) models
     %======================================================================
     case{'hierarchical linear model','hlm','peb','mfx'}

--- a/toolbox/DEM/spm_MDP_VB_X.m
+++ b/toolbox/DEM/spm_MDP_VB_X.m
@@ -282,7 +282,7 @@ for m = 1:size(MDP,1)
             A{m,g}  = spm_norm(MDP(m).A{g});
         end
         
-        % prior concentration paramters for complexity (and novelty)
+        % prior concentration parameters for complexity (and novelty)
         %------------------------------------------------------------------
         if isfield(MDP,'a')
             pA{m,g} = MDP(m).a{g};
@@ -312,7 +312,7 @@ for m = 1:size(MDP,1)
             
         end
         
-        % prior concentration paramters for complexity
+        % prior concentration parameters for complexity
         %------------------------------------------------------------------
         if isfield(MDP,'b')
             pB{m,f} = MDP(m).b{f};
@@ -333,7 +333,7 @@ for m = 1:size(MDP,1)
             MDP(m).D{f} = D{m,f};
         end
         
-        % prior concentration paramters for complexity
+        % prior concentration parameters for complexity
         %------------------------------------------------------------------
         if isfield(MDP,'d')
             pD{m,f} = MDP(m).d{f};
@@ -352,7 +352,7 @@ for m = 1:size(MDP,1)
     end
     qE{m}    = spm_log(E{m});
     
-    % prior concentration paramters for complexity
+    % prior concentration parameters for complexity
     %----------------------------------------------------------------------
     if isfield(MDP,'e')
         pE{m} = MDP(m).e;
@@ -839,7 +839,7 @@ for t = 1:T
                                 %------------------------------------------
                                 qx  = spm_log(sx);
                                 
-                                % emprical priors (forward messages)
+                                % empirical priors (forward messages)
                                 %------------------------------------------
                                 if j < 2
                                     px = spm_log(D{m,f});
@@ -849,7 +849,7 @@ for t = 1:T
                                     v  = v + px + qL - qx;
                                 end
                                 
-                                % emprical priors (backward messages)
+                                % empirical priors (backward messages)
                                 %------------------------------------------
                                 if j < R
                                     px = spm_log(rB{m,f}(:,:,V{m}(j    ,k,f))*x{m,f}(:,j + 1,k));
@@ -901,7 +901,7 @@ for t = 1:T
             if Np(m) > 1
                 for k = p{m}
                     
-                    % Bayesian surprise about inital conditions
+                    % Bayesian surprise about initial conditions
                     %------------------------------------------------------
                     if isfield(MDP,'d')
                         for f = 1:Nf(m)

--- a/toolbox/DEM/spm_MDP_VB_XX.m
+++ b/toolbox/DEM/spm_MDP_VB_XX.m
@@ -300,7 +300,7 @@ for m = 1:size(MDP,1)
             
         end
         
-        % prior concentration paramters for novelty
+        % prior concentration parameters for novelty
         %------------------------------------------------------------------
         if isfield(MDP,'b')
             pB{m,f} = MDP(m).b{f};
@@ -333,7 +333,7 @@ for m = 1:size(MDP,1)
             MDP(m).D{f} = D{m,f};
         end
         
-        % prior concentration paramters for novelty
+        % prior concentration parameters for novelty
         %------------------------------------------------------------------
         if isfield(MDP,'d')
             pD{m,f} = MDP(m).d{f};
@@ -351,7 +351,7 @@ for m = 1:size(MDP,1)
     end
     E{m}     = spm_log(E{m});
     
-    % prior concentration paramters for habits
+    % prior concentration parameters for habits
     %----------------------------------------------------------------------
     if isfield(MDP,'e')
         pE{m} = MDP(m).e;
@@ -851,7 +851,7 @@ for t = 1:T
         %==================================================================
         if t < T
             
-            % record emprical prior over policies (R) and sample a policy (K)
+            % record empirical prior over policies (R) and sample a policy (K)
             %--------------------------------------------------------------
             R{m}(:,t)      = u{m,t};
             Ru             = spm_softmax(alpha*log(u{m,t}));

--- a/toolbox/DEM/spm_MDP_VB_XXX.m
+++ b/toolbox/DEM/spm_MDP_VB_XXX.m
@@ -1540,7 +1540,7 @@ for v = 1:4
     qa   = a(m,:);
     qb   = b(m,:);
 
-    % acccumulate posterior Dirichlet parameters
+    % accumulate posterior Dirichlet parameters
     %======================================================================
     for t = 1:T
 

--- a/toolbox/DEM/spm_MDP_VB_game.m
+++ b/toolbox/DEM/spm_MDP_VB_game.m
@@ -129,7 +129,7 @@ end
 if nargout
     Q.X  = x;            % expected hidden states
     Q.R  = u;            % final policy expectations
-    Q.S  = s;            % inital hidden states
+    Q.S  = s;            % initial hidden states
     Q.O  = o;            % final outcomes
     Q.p  = p;            % performance
     Q.q  = q;            % reaction times

--- a/toolbox/DEM/spm_mountaincar_fun.m
+++ b/toolbox/DEM/spm_mountaincar_fun.m
@@ -27,7 +27,7 @@ function [f] = spm_mountaincar_fun(P,G)
 % Copyright (C) 2008-2022 Wellcome Centre for Human Neuroimaging
  
  
-% place paramters in model
+% place parameters in model
 %--------------------------------------------------------------------------
 G(1).pE = P;
  

--- a/toolbox/DEM/spm_voice.m
+++ b/toolbox/DEM/spm_voice.m
@@ -302,7 +302,7 @@ end
 
 
 
-%% Illustrate mapping from formant space to coeficients
+%% Illustrate mapping from formant space to coefficients
 %==========================================================================
 spm_figure('GetWin','Formant priors'); clf
 VOX.analysis = 0;

--- a/toolbox/DEM/spm_voice_get_LEX.m
+++ b/toolbox/DEM/spm_voice_get_LEX.m
@@ -160,7 +160,7 @@ for i = 1:4
             
         end
         
-        % expected formant coeficients and moments of pitch
+        % expected formant coefficients and moments of pitch
         %------------------------------------------------------------------
         LEX(w).pE  = LEX(w).pE/2 + mean(dP,2)/2;
         LEX(w).pC  = LEX(w).pC/2 + cov(dP')/2;

--- a/toolbox/DEM/spm_voice_get_word.m
+++ b/toolbox/DEM/spm_voice_get_word.m
@@ -68,7 +68,7 @@ if isempty(I)
     
 elseif I < 1
     
-    % deal with negative I (inital index)
+    % deal with negative I (initial index)
     %----------------------------------------------------------------------
     i    = 1:FS/32;
     Y(i) = 0;

--- a/toolbox/DEM/spm_voice_iQ.m
+++ b/toolbox/DEM/spm_voice_iQ.m
@@ -7,7 +7,7 @@ function [W] = spm_voice_iQ(Q)
 % G(2)  - log timing  (pitch) Tv
 
 %
-% W     - (Nu x Nv) log formant coeficients (weights)
+% W     - (Nu x Nv) log formant coefficients (weights)
 %
 %   Nu  - number of formant coefficients
 %   Nv  - number of timing  coefficients
@@ -37,5 +37,5 @@ try, Tv = VOX.Tv; catch, Tv  = 1;          end    % log scaling (interval)
 %--------------------------------------------------------------------------
 U  = spm_voice_dct(Ni,Nu,Tu);                % DCT over formants
 V  = spm_voice_dct(ni,Nv,Tv);                % DCT over intervals
-W  = U\Q/V';                                 % coeficients
+W  = U\Q/V';                                 % coefficients
 W  = W/std(W(:));                            % normalise

--- a/toolbox/MB/fil_fit.m
+++ b/toolbox/MB/fil_fit.m
@@ -72,7 +72,7 @@ end
 % Indices
 csi = cumsum(ind,1);
 
-% Assingn V to each z based on the average
+% Assign V to each z based on the average
 Vc  = cell(numel(mod),1);
 for l=1:numel(mod)
     Vc{l} = zeros([K K sum(ind(:,l))],'single');

--- a/toolbox/MB/spm_mb_shape.m
+++ b/toolbox/MB/spm_mb_shape.m
@@ -595,7 +595,7 @@ for k=1:K
     % Diagonal elements of Hessian
     h_kk = hessel(k,k,K,accel,s).*w;
 
-    % Dot product betwen off-diagonals of likelihood Hessian and x
+    % Dot product between off-diagonals of likelihood Hessian and x
     g_k = zeros(d(1:3),'single');
     for k1=1:K
         if k1~=k, g_k = g_k + x(:,:,:,k1).*hessel(k,k1,K,accel,s); end
@@ -1009,7 +1009,7 @@ datn       = set_def(datn,sett.ms.Mmu,psi1);
 function [mu,te] = zoom_mean(mu,sett,oMmu)
 ms    = sett.ms;
 y     = affine(ms.d, oMmu\ms.Mmu);
-spm_diffeo('boundary',1);  % Neumann bounday for template
+spm_diffeo('boundary',1);  % Neumann boundary for template
 mu    = spm_diffeo('pullc', mu, y);
 if nargout>=2
     te = template_energy(mu, ms.mu_settings);

--- a/toolbox/Neural_Models/NMDA_NMM_MFM/spm_dcm_x_neural_NMDA.m
+++ b/toolbox/Neural_Models/NMDA_NMM_MFM/spm_dcm_x_neural_NMDA.m
@@ -21,7 +21,7 @@ switch lower(model)
     %======================================================================
     case{'erp'}
 
-        % inital states and equations of motion
+        % initial states and equations of motion
         %------------------------------------------------------------------
         x  =  spm_x_erp(P);
         f  = 'spm_fx_erp';
@@ -31,7 +31,7 @@ switch lower(model)
     %======================================================================
     case{'sep'}
 
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         x  =  spm_x_erp(P);
         f  = 'spm_fx_erp';
@@ -40,7 +40,7 @@ switch lower(model)
     %======================================================================
     case{'lfp'}
 
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         x  =  spm_x_lfp(P);
         f  = 'spm_fx_lfp';
@@ -50,7 +50,7 @@ switch lower(model)
     %======================================================================
     case{'nmm'}
 
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = spm_x_nmm_NMDA(P);
         f  = 'spm_fx_mfm_NMDA';
@@ -60,7 +60,7 @@ switch lower(model)
     %======================================================================
     case{'mfm'}
 
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = spm_x_mfm_NMDA(P);
         f  = 'spm_fx_mfm_NMDA';

--- a/toolbox/Neural_Models/NMDA_NMM_MFM/spm_fx_mfm_NMDA.m
+++ b/toolbox/Neural_Models/NMDA_NMM_MFM/spm_fx_mfm_NMDA.m
@@ -130,7 +130,7 @@ GL   = 1;                                    % leak conductance
 %%% approx curvature got NMDA entry
 
  
-% mean-field effects: the paramters of the sigmoid activation function
+% mean-field effects: the parameters of the sigmoid activation function
 %==========================================================================
 if mfm
     

--- a/toolbox/OldNorm/spm_affreg.m
+++ b/toolbox/OldNorm/spm_affreg.m
@@ -273,7 +273,7 @@ for iter=1:256
 
     if est_smo
         % Compute a smoothness correction from the residuals and their
-        % derivatives.  This is analagous to the one used in:
+        % derivatives.  This is analogous to the one used in:
         %   "Analysis of fMRI Time Series Revisited"
         %   Friston KJ, Holmes AP, Poline JB, Grasby PJ, Williams SCR,
         %   Frackowiak RSJ, Turner R.  Neuroimage 2:45-53 (1995).

--- a/toolbox/dcm_fnirs/mmclab/estimate_greens_mmclab.m
+++ b/toolbox/dcm_fnirs/mmclab/estimate_greens_mmclab.m
@@ -175,7 +175,7 @@ for i = 1:nvox
     srcpos(i,:) = cent_e(indx,:);
 end
 
-% find an inital direction of photon movement 
+% find an initial direction of photon movement 
 % normal vector to tetrahedral volume face is calculated. 
 AB=node(face(:,2),1:3)-node(face(:,1),1:3);
 AC=node(face(:,3),1:3)-node(face(:,1),1:3);

--- a/toolbox/dcm_meeg/spm_api_erp.m
+++ b/toolbox/dcm_meeg/spm_api_erp.m
@@ -428,7 +428,7 @@ if isequal(mod, 'Multimodal')
         handles.DCM.xY.modality = questdlg(qstr, 'Select modality', list{:}, options);
         
     else
-        % Ugly but can accomodate more buttons
+        % Ugly but can accommodate more buttons
         %------------------------------------------------------------------
         ind = menu(qstr, list);
         handles.DCM.xY.modality = list{ind};
@@ -857,7 +857,7 @@ for i = 1:n
                 set(A{k}(i,j),'Enable','off')
             end
 
-            % allow nonlinear self-connections when appriopriate
+            % allow nonlinear self-connections when appropriate
             %--------------------------------------------------------------
             if strcmpi(DCM.options.analysis,'IND') && k == 2
                 set(A{k}(i,j),'Enable','on')

--- a/toolbox/dcm_meeg/spm_dcm_csd_data.m
+++ b/toolbox/dcm_meeg/spm_dcm_csd_data.m
@@ -86,7 +86,7 @@ if ~isfield(DCM.xY, 'modality')
             DCM.xY.modality = questdlg(qstr, 'Select modality', list{:}, options);
         else
             
-            % accomodate more buttons
+            % accommodate more buttons
             %--------------------------------------------------------------
             ind = menu(qstr, list);
             DCM.xY.modality = list{ind};

--- a/toolbox/dcm_meeg/spm_dcm_csd_priors.m
+++ b/toolbox/dcm_meeg/spm_dcm_csd_priors.m
@@ -144,7 +144,7 @@ for  i = 1:length(feilds)
             if any(pM - pF)
                 pF = pM - pM + pF;
                 pE = setfield(pE,feilds{i},pF);
-                fprintf('paramters %s optimised\n',feilds{i})
+                fprintf('parameters %s optimised\n',feilds{i})
             end
         end
     end

--- a/toolbox/dcm_meeg/spm_dcm_phase_data.m
+++ b/toolbox/dcm_meeg/spm_dcm_phase_data.m
@@ -92,7 +92,7 @@ for jj=1:length(chosen_conds)
     X=[X;ones(length(new_trials),1)*DCM.xU.X(jj)];
 end
 
-% Change DCM.xU to accomodate these trial indices
+% Change DCM.xU to accommodate these trial indices
 DCM.xU.oldX=DCM.xU.X;
 DCM.xU.X=X;
 

--- a/toolbox/dcm_meeg/spm_dcm_ssr.m
+++ b/toolbox/dcm_meeg/spm_dcm_ssr.m
@@ -110,7 +110,7 @@ DCM.M.Hz  = DCM.xY.Hz;
 DCM.xY.Q  = spm_Q(1/2,Nf,1);
 DCM.xY.X0 = sparse(Nf,0);
 
-% adjust priors on gain to accomodate scaling differences among models
+% adjust priors on gain to accommodate scaling differences among models
 %--------------------------------------------------------------------------
 Hc        = feval(DCM.M.IS,DCM.M.pE,DCM.M,DCM.xU);
 DCM.M.U   = U*sqrt(norm(spm_vec(DCM.xY.y),Inf)/norm(spm_vec(Hc),Inf));

--- a/toolbox/dcm_meeg/spm_dcm_ssr_data.m
+++ b/toolbox/dcm_meeg/spm_dcm_ssr_data.m
@@ -83,7 +83,7 @@ if ~isfield(DCM.xY, 'modality')
             options.Interpreter = 'none';
             DCM.xY.modality = questdlg(qstr, 'Select modality', list{:}, options);
         else
-            % Ugly but can accomodate more buttons
+            % Ugly but can accommodate more buttons
             ind = menu(qstr, list);
             DCM.xY.modality = list{ind};
         end

--- a/toolbox/dcm_meeg/spm_dcm_x_neural.m
+++ b/toolbox/dcm_meeg/spm_dcm_x_neural.m
@@ -44,7 +44,7 @@ switch lower(model)
     %======================================================================
     case{'erp'}
         
-        % inital states and equations of motion
+        % initial states and equations of motion
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 9;                                       % number of states
@@ -57,7 +57,7 @@ switch lower(model)
     %======================================================================
     case{'sep'}
         
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 9;                                       % number of states
@@ -69,7 +69,7 @@ switch lower(model)
     %======================================================================
     case{'cmc'}
         
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 8;                                       % number of states
@@ -82,7 +82,7 @@ switch lower(model)
     %======================================================================
     case{'tfm'}
         
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 8;                                       % number of states
@@ -95,7 +95,7 @@ switch lower(model)
     %======================================================================
     case{'lfp'}
         
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 13;                                      % number of states
@@ -136,7 +136,7 @@ switch lower(model)
     %======================================================================
     case{'cmm'}
         
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = spm_x_cmm(P);
         f  = 'spm_fx_cmm';
@@ -145,7 +145,7 @@ switch lower(model)
     %======================================================================
     case{'cmm_nmda'}
         
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = spm_x_cmm_NMDA(P);
         f  = 'spm_fx_cmm_NMDA';
@@ -155,7 +155,7 @@ switch lower(model)
     %======================================================================
     case{'mfm'}
         
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = spm_x_mfm(P);
         f  = 'spm_fx_mfm';
@@ -165,7 +165,7 @@ switch lower(model)
     %======================================================================
     case{'bgt'}
         
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         n = length(1);
         m = 10;
@@ -177,7 +177,7 @@ switch lower(model)
     %======================================================================
     case{'mmc'}
         
-        % inital states
+        % initial states
         %------------------------------------------------------------------
         n  = length(P.A{1});                          % number of sources
         m  = 8;                                       % number of states
@@ -189,7 +189,7 @@ switch lower(model)
     %======================================================================
     case{'null'}
         
-        % inital states and model
+        % initial states and model
         %------------------------------------------------------------------
         x  = sparse(size(P.A,1),1);
         f  = 'spm_fx_null';

--- a/toolbox/dcm_meeg/spm_erp_L.m
+++ b/toolbox/dcm_meeg/spm_erp_L.m
@@ -14,7 +14,7 @@ function [L] = spm_erp_L(P,dipfit)
 %    'ECD', 'LFP' or 'IMG'
 %
 % determines whether the model is ECD or not. For imaging reconstructions
-% the paramters P.L are a (m x n) matrix of coefficients that scale the
+% the parameters P.L are a (m x n) matrix of coefficients that scale the
 % contrition of n sources to m = dipfit.Nm modes encoded in dipfit.G.
 %
 % For LFP models (the default) P.L simply encodes the electrode gain for 
@@ -84,7 +84,7 @@ switch type
         %------------------------------------------------------------------
         n  = size(P.L,2);
 
-        % re-compute lead field only if any coeficients have changed
+        % re-compute lead field only if any coefficients have changed
         %------------------------------------------------------------------
         try
             Id = find(any(LastLpos ~= P.L));

--- a/toolbox/dcm_meeg/spm_fx_mfm.m
+++ b/toolbox/dcm_meeg/spm_fx_mfm.m
@@ -124,7 +124,7 @@ CV   = exp(P.CV)*8/1000;                     % membrane capacitance
 GL   = 1;                                    % leak conductance
 fxx  = sparse([2 3 1 1],[1 1 2 3],-1/CV);    % curvature: df(V)/dxx
  
-% mean-field effects: the paramters of the sigmoid activation function
+% mean-field effects: the parameters of the sigmoid activation function
 %==========================================================================
 if mfm
     

--- a/toolbox/dcm_meeg/spm_fx_nmda.m
+++ b/toolbox/dcm_meeg/spm_fx_nmda.m
@@ -132,7 +132,7 @@ CV   = exp(P.CV)*8/1000;                  % membrane capacitance
 GL   = 1;                                 % leak conductance
 fxx  = sparse([2 3 1 1],[1 1 2 3],-1/CV); % curvature: df(V)/dxx
  
-% mean-field effects: the paramters of the sigmoid activation function
+% mean-field effects: the parameters of the sigmoid activation function
 %==========================================================================
 if mfm
     

--- a/toolbox/spectral/spm_ccf2mar.m
+++ b/toolbox/spectral/spm_ccf2mar.m
@@ -6,8 +6,8 @@ function [mar,pcond] = spm_ccf2mar(ccf,p)
 % p              - AR(p) order [default: p = 8]
 %
 % mar.noise_cov  - (m,m)         covariance of innovations   
-% mar.mean       - (p*m,m)       MAR coeficients (matrix format - positive)
-% mar.lag        - lag(p).a(m,m) MAR coeficients (array format  - negative)
+% mar.mean       - (p*m,m)       MAR coefficients (matrix format - positive)
+% mar.lag        - lag(p).a(m,m) MAR coefficients (array format  - negative)
 % mar.p          - order of a AR(p) model
 %
 % See also:
@@ -23,7 +23,7 @@ function [mar,pcond] = spm_ccf2mar(ccf,p)
 %--------------------------------------------------------------------------
 if nargin < 2, p  = 8; end                           
 
-% MAR coeficients
+% MAR coefficients
 %==========================================================================
 N     = size(ccf,1);
 m     = size(ccf,2);

--- a/toolbox/spectral/spm_csd2mar.m
+++ b/toolbox/spectral/spm_csd2mar.m
@@ -23,7 +23,7 @@ function [mar] = spm_csd2mar(csd,Hz,p,dt)
 if nargin < 3, p = 8;              end
 if nargin < 4, dt = 1/(2*Hz(end)); end
  
-% FFT and evaluate MAR coeficients
+% FFT and evaluate MAR coefficients
 %--------------------------------------------------------------------------
 ccf  = spm_csd2ccf(csd,Hz,dt);
 mar  = spm_ccf2mar(ccf,p);

--- a/toolbox/spectral/spm_mar2ccf.m
+++ b/toolbox/spectral/spm_mar2ccf.m
@@ -27,7 +27,7 @@ function [ccf] = spm_mar2ccf(mar,n)
 if nargin < 2, n = 128; end
 
 
-% format coefficients into an array of negative coeficients (cf lag.a)
+% format coefficients into an array of negative coefficients (cf lag.a)
 %--------------------------------------------------------------------------
 if isvector(mar) && isnumeric(mar)
     mar = mar(:);

--- a/toolbox/spectral/spm_mar2csd.m
+++ b/toolbox/spectral/spm_mar2csd.m
@@ -30,7 +30,7 @@ function [csd,mtf,coh,pha] = spm_mar2csd(mar,Hz,ns)
 %--------------------------------------------------------------------------
 if nargin < 3, ns = 2*Hz(end); end
 
-% format coefficients into an array of negative coeficients (cf lag.a)
+% format coefficients into an array of negative coefficients (cf lag.a)
 %--------------------------------------------------------------------------
 if isvector(mar) && isnumeric(mar)
     mar = mar(:);

--- a/toolbox/spectral/spm_mmtspec.m
+++ b/toolbox/spectral/spm_mmtspec.m
@@ -99,7 +99,7 @@ eJ = complex(zeros(nFFT, nFFTChunks));
 Tapers=spm_dpss(max(nFFT,WinLength),NW);
 Tapers=Tapers(:,1:nTapers);
 
-% Vectorized alogrithm for computing tapered periodogram with FFT 
+% Vectorized algorithm for computing tapered periodogram with FFT 
 TaperingArray = repmat(Tapers, [1 1 nChannels]);
 for j=1:nFFTChunks
     Segment = x((j-1)*winstep+[1:WinLength], :);


### PR DESCRIPTION
Here are typos with their counts and introduced fix:

      1 abritrary ==> arbitrary
      1 acccumulate ==> accumulate
      1 accidentaly ==> accidentally
      1 accordin ==> according
      1 acocunt ==> account
      1 additionaly ==> additionally
      1 adresses ==> addresses
      1 adviced ==> advised
      1 Algorithim ==> Algorithm
      1 alignement ==> alignment
      1 alogorithm ==> algorithm
      1 alogrithm ==> algorithm
      1 alowed ==> allowed
      1 analagous ==> analogous
      1 ananlysis ==> analysis
      1 appriopriate ==> appropriate
      1 appriximately ==> approximately
      1 appropiately ==> appropriately
      1 aproach ==> approach
      1 aproximation ==> approximation
      1 assesment ==> assessment
      1 Assingn ==> Assign
      1 assmptions ==> assumptions
      1 betwen ==> between
      1 beween ==> between
      1 bootstap ==> bootstrap
      1 bootstraping ==> bootstrapping
      1 boudary ==> boundary
      1 bounday ==> boundary
      1 caculate ==> calculate
      1 canoncial ==> canonical
     10 explicitely ==> explicitly
     11 emprical ==> empirical
     13 coeficients ==> coefficients
     15 detailled ==> detailed
     16 paramters ==> parameters
     17 accomodate ==> accommodate
     20 inital ==> initial
     21 usefull ==> useful
     25 occurences ==> occurrences

There are more but this was the first batch to swallow ;-)