### PR TITLE
Test: Add macos-latest as target

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["R2020a", "R2020b", "R2021a", "R2021b", "R2022a", "R2022b", "R2023a", "R2023b", "R2024a"]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest", "windows-latest"] # macos-13 has Intel architecture, macos-latest has Apple Silicon
         exclude:
           - os: windows-latest
             version: "R2020a" # MATLAB not available
@@ -24,11 +24,25 @@ jobs:
             version: "R2021a" # Compiler not available
           - os: windows-latest
             version: "R2021b" # Compiler not available
+          - os: macos-latest
+            version: "R2020a" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2020b" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2021a" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2021b" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2022a" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2022b" # Apple Silicon version not available
+          - os: macos-latest
+            version: "R2023a" # Apple Silicon version not available
     runs-on: ${{matrix.os}}
     steps:
       - name: Set up MATLAB (legacy)
         if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
-        uses: matlab-actions/setup-matlab@v1        
+        uses: matlab-actions/setup-matlab@v1
         with:
           release: ${{matrix.version}}
       - name: Set up MATLAB
@@ -36,6 +50,7 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{matrix.version}}
+
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Setup cached test data folder
@@ -45,23 +60,35 @@ jobs:
           path: tests/data
           key: tests-data
           enableCrossOsArchive: true
-      - name: Check out test data to latest 
+      - name: Check out test data to latest
         uses: actions/checkout@v4
-        with: 
+        with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
           path: tests/data
           lfs: true
-      - name: Run regression tests with existing MEX files
-        if: github.event.schedule == '40 16 * * 3'
-        uses: matlab-actions/run-command@v1 # R2020b fails with run-command@v2
+
+      - name: Run regression tests with existing MEX files (legacy)
+        if: ${{github.event.schedule == '40 16 * * 3' && (matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b')}}
+        uses: matlab-actions/run-command@v1
         with:
           command: addpath(pwd); results = spm_tests('class','regression','display',true); assert(all(~[results.Failed]));
-      - name: Run unit tests with existing MEX files
-        if: github.event.schedule != '40 16 * * 3'
+      - name: Run unit tests with existing MEX files (legacy)
+        if: ${{github.event.schedule != '40 16 * * 3' && (matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b')}}
         uses: matlab-actions/run-command@v1
         with:
           command: addpath(pwd); results = spm_tests('class','unit','display',true); assert(all(~[results.Failed]));
+      - name: Run regression tests with existing MEX files
+        if: ${{github.event.schedule == '40 16 * * 3' && matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
+        uses: matlab-actions/run-command@v2
+        with:
+          command: addpath(pwd); results = spm_tests('class','regression','display',true); assert(all(~[results.Failed]));
+      - name: Run unit tests with existing MEX files
+        if: ${{github.event.schedule != '40 16 * * 3' && matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
+        uses: matlab-actions/run-command@v2
+        with:
+          command: addpath(pwd); results = spm_tests('class','unit','display',true); assert(all(~[results.Failed]));
+
       - name: Compile MEX files
         run: |
           make -C src distclean


### PR DESCRIPTION
macos-latest uses Apple Silicon hardware and is supported since Matlab R2023b
It's probably best to test both, macos-13 (Intel) and macos-latest (Apple Silicon)

macos-latest requires matlab-actions/run-command@v2, which was only possible to add with some more code duplication. It is probably still better than having two separate workflows.

It was tested here: https://github.com/korbinian90/spm/actions/runs/10062331645