### PR TITLE
Octave compatibility

### DIFF
--- a/matlabbatch/cfg_util.m
+++ b/matlabbatch/cfg_util.m
@@ -1790,7 +1790,7 @@ else
                         '#job as displayed in this error message)\n' ...
                         '------------------ \nRunning job #%d' ...
                         '\n------------------\n'], cjob);
-    err.stack      = struct('file','','name','MATLABbatch system','line',0);
+    err.stack      = struct('file','','name','MATLABbatch system','line',0,'column',0);
 end
 if cfg_get_defaults('cfg_util.run_diary')
     diary off

--- a/spm_check_version.m
+++ b/spm_check_version.m
@@ -69,13 +69,14 @@ function varargout = spm_check_version(tbx,chk)
 
 %-Detect software used
 %==========================================================================
-if ~nargin || isempty(tbx)
-    if exist('OCTAVE_VERSION','builtin')
-        tbx = 'octave';
-    else
-        tbx = 'matlab';
-    end
-    if ~nargin, varargout = {tbx}; return; end
+if exist('OCTAVE_VERSION','builtin')
+    runtime = 'octave';
+else
+    runtime = 'matlab';
+end
+if ~nargin, varargout = {runtime}; return; end
+if isempty(tbx) % Not sure whether this should actually happen
+    tbx = runtime;
 end
 
 
@@ -88,6 +89,10 @@ if strcmpi(tbx,'matlab')
 elseif strcmpi(tbx,'octave')
     tbxVer = version;
     tbxVer = strrep(tbxVer,'+','');
+elseif strcmpi(tbx,'spm')
+    % Octave does not consider SPM a toolbox unless it is packaged. Use raw
+    % SPM versioning instead.
+    [~, tbxVer] = spm('Ver','',1);
 else
     tbxStruct = ver(tbx);
     if isempty(tbxStruct)
@@ -98,19 +103,13 @@ else
     tbxVer = tbxStruct.Version;
 end
 
+% Return raw version string if no check requested
 if nargin == 1, varargout = {tbxVer}; return; end
 
 
-%-Parse user supplied version number
-%==========================================================================
-
-if strcmpi(tbx,'matlab') && strcmpi(spm_check_version,'octave')
-    varargout = {1}; % hack
-    return;
-end
-
 % SPM-specific versioning
 %--------------------------------------------------------------------------
+% Skip version checks for various SPM versions
 if strcmpi(tbx,'spm')
     [v,r] = spm('Ver','',1);
     % The release string can take the following forms:
@@ -145,13 +144,29 @@ end
 
 % Check if running MATLAB Online
 %--------------------------------------------------------------------------
-if strcmpi(chk, 'online') 
+if strcmpi(tbx, 'matlab') && strcmpi(chk, 'online')
     % No builtin MATLAB function to check this. 
     % Check for 'MATLAB Drive' drive. 
     status = logical(exist(fullfile(filesep, 'MATLAB Drive'), 'dir')); 
     varargout = {status};
     return;
 end
+
+% Bail out if running on octave, but requested check on MATLAB
+%--------------------------------------------------------------------------
+if strcmpi(runtime, 'octave') && strcmpi(tbx, 'matlab')
+    if strcmpi(chk, 'online')
+        varargout = {0};
+    else
+        warning('Running on octave, but version check requested for MATLAB.');
+        varargout = {1};
+    end
+    return;
+end
+
+
+%-Parse user supplied version number
+%==========================================================================
 
 % If a number is supplied then convert to text
 %--------------------------------------------------------------------------

--- a/spm_dicom_convert.m
+++ b/spm_dicom_convert.m
@@ -1321,7 +1321,7 @@ if isfield(Header,'GE_ImageType')
         end
     end
 else
-    if isfield(Header,'ImageType') && ~isempty(regexp(Header.ImageType,'\P\'))
+    if isfield(Header,'ImageType') && ~isempty(regexp(Header.ImageType,'\\P\\'))
         ImTyp = '-Phase';
     end
 end

--- a/spm_dicom_convert.m
+++ b/spm_dicom_convert.m
@@ -1114,7 +1114,13 @@ if Header.SamplesPerPixel ~= 1
     return;
 end
 
-prec = ['ubit' num2str(Header.BitsAllocated) '=>' 'uint32'];
+if strcmpi(spm_check_version, 'matlab')
+    prec = ['ubit' num2str(Header.BitsAllocated) '=>' 'uint32'];
+else
+    % Octave fread doesn't recognise ubit, but BitsAllocated should align
+    % to some sort of uint anyway
+    prec = ['uint' num2str(Header.BitsAllocated) '=>' 'uint32'];
+end
 
 if isfield(Header,'TransferSyntaxUID') && strcmp(Header.TransferSyntaxUID,'1.2.840.10008.1.2.2') && strcmp(Header.VROfPixelData,'OW')
     fp = fopen(Header.Filename,'r','ieee-be');


### PR DESCRIPTION
While SPM has become quite compatible to current Octave versions (9.x upwards), there are still things that work slightly different in Octave compared to MATLAB. Major changes are code rearrangements in spm_check_version, such that MATLAB specific runtime checks pass on Octave and Octave specific changes can be added more easily.

The other changes address details that are handled differently in MATLAB and Octave.