### PR TITLE
Maintenance: convert tests to class-based; add standalone testing workflow

### DIFF
--- a/.github/workflows/install_test_standalone.yml
+++ b/.github/workflows/install_test_standalone.yml
@@ -1,0 +1,445 @@
+name: Test SPM Standalone
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source of standalone binaries'
+        required: false
+        default: 'build'
+        type: choice
+        options:
+          - build
+          - release
+      release_tag:
+        description: 'Release tag (only for release source)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      source:
+        description: 'Source of standalone binaries'
+        required: false
+        default: 'release'
+        type: string
+      release_tag:
+        description: 'Release tag'
+        required: true
+        type: string
+
+env:
+  MLM_LICENSE_TOKEN: ${{ secrets.MATLAB_BATCH_TOKEN }}
+
+jobs:
+  download_test_data:
+    name: Download Test Data
+    runs-on: ubuntu-latest
+    env:
+      cache-key: tests-data2
+    steps:
+      - name: Get latest commit for tests data
+        id: checkout-tests-data
+        uses: actions/checkout@v4
+        with:
+          repository: spm/spm-tests-data
+          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          path: tests/data
+          fetch-depth: 1
+          lfs: false
+      
+      - name: Remove shallow-checked-out repo
+        shell: bash
+        run: rm -rf tests/data
+      
+      - name: Try to retrieve commit from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: tests/data
+          key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
+          restore-keys: ${{ env.cache-key }}
+          enableCrossOsArchive: true
+      
+      - name: If cache missed, pull latest commit
+        id: checkout-tests-data-lfs
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: spm/spm-tests-data
+          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          path: tests/data
+          lfs: true
+      
+      - name: Cache latest commit
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: tests/data
+          key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
+      
+      - name: Upload test data as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-data
+          path: tests/data
+          retention-days: 1
+
+  download_release_standalone:
+    name: Download Release Standalone
+    if: inputs.source == 'release'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os_name: [Linux, macOS_Intel, macOS_Apple_Silicon, Windows]
+    steps:
+      - name: Download release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          OS_NAME="${{ matrix.os_name }}"
+          
+          # Map os_name to release asset name
+          case "$OS_NAME" in
+            Linux)
+              ASSET_NAME="spm_standalone_Linux.zip"
+              ;;
+            macOS_Intel)
+              ASSET_NAME="spm_standalone_macOS_Intel.zip"
+              ;;
+            macOS_Apple_Silicon)
+              ASSET_NAME="spm_standalone_macOS_Apple_Silicon.zip"
+              ;;
+            Windows)
+              ASSET_NAME="spm_standalone_Windows.zip"
+              ;;
+          esac
+          
+          echo "Downloading $ASSET_NAME from release $TAG"
+          gh release download "$TAG" --repo ${{ github.repository }} --pattern "$ASSET_NAME"
+      
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spm-standalone-${{ matrix.os_name }}
+          path: spm_standalone_${{ matrix.os_name }}.zip
+          retention-days: 1
+
+  build_standalone:
+    name: Build Standalone on ${{ matrix.os_name }}
+    if: inputs.source == 'build' || inputs.source == ''
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-15-intel", "macos-latest", "windows-latest"]
+        include:
+          - os: ubuntu-latest
+            os_name: Linux
+          - os: macos-15-intel
+            os_name: macOS_Intel
+          - os: macos-latest
+            os_name: macOS_Apple_Silicon
+          - os: windows-latest
+            os_name: Windows
+
+    steps:
+      - name: Checkout SPM
+        uses: actions/checkout@v4
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: latest
+          products: |
+            MATLAB_Compiler
+            Signal_Processing_Toolbox
+
+      - name: Extract MATLAB version to file
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            fileID = fopen('matlab_release.txt', 'w');
+            fprintf(fileID, matlabRelease.Release);
+            fclose(fileID);
+        timeout-minutes: 2
+        continue-on-error: true
+
+      - name: Set environment variable with MATLAB version
+        shell: bash
+        run: |
+          matlab_release=$(cat matlab_release.txt)
+          echo "MATLAB_VERSION=$matlab_release" >> $GITHUB_ENV
+
+      # Build the standalone
+      - name: Build MATLAB standalone
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            addpath(genpath('.'));
+            savepath;
+            spm_make_standalone
+            mkdir('runtime_installer');
+            if ~isMATLABReleaseOlderThan("R2024b")
+              compiler.runtime.customInstaller('Runtime_${{ env.MATLAB_VERSION }}_for_spm_standalone', '../standalone/requiredMCRProducts.txt', OutputDir='../runtime_installer');
+            end
+
+      # Install zip on Windows
+      - name: Install zip on Windows
+        if: runner.os == 'Windows'
+        run: choco install zip -y
+        shell: bash
+
+      # Compress standalone for artifact upload (same as release.yml)
+      - name: Compress standalone
+        shell: bash
+        run: |
+          cd ..
+          mv standalone spm_standalone
+          ls -la
+          echo "Contents of spm_standalone:"
+          ls -la spm_standalone | head -20
+          echo "Contents of runtime_installer:"
+          ls -la runtime_installer | head -20
+          zip -r spm_standalone_${{ matrix.os_name }}.zip spm_standalone runtime_installer
+          mv spm_standalone_${{ matrix.os_name }}.zip spm/
+          echo "Verifying ZIP contents:"
+          unzip -l spm/spm_standalone_${{ matrix.os_name }}.zip | head -30
+
+      # Upload standalone as artifact
+      - name: Upload standalone artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spm-standalone-${{ matrix.os_name }}
+          path: spm_standalone_${{ matrix.os_name }}.zip
+          retention-days: 7
+
+  test_standalone:
+    name: Test Standalone on ${{ matrix.os_name }}
+    needs: [download_test_data, build_standalone, download_release_standalone]
+    if: |
+      always() && 
+      needs.download_test_data.result == 'success' &&
+      (needs.build_standalone.result == 'success' || needs.download_release_standalone.result == 'success')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-15-intel", "macos-latest", "windows-latest"]
+        include:
+          - os: ubuntu-latest
+            os_name: Linux
+          - os: macos-15-intel
+            os_name: macOS_Intel
+          - os: macos-latest
+            os_name: macOS_Apple_Silicon
+          - os: windows-latest
+            os_name: Windows
+
+    steps:
+      - name: Download standalone artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spm-standalone-${{ matrix.os_name }}
+          path: .
+
+      # Extract standalone
+      - name: Extract standalone
+        shell: bash
+        run: |
+          unzip -q spm_standalone_${{ matrix.os_name }}.zip
+          ls -la spm_standalone
+          ls -la runtime_installer
+
+      # Install MATLAB Runtime from runtime_installer
+      - name: Install MATLAB Runtime (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          INSTALLER=$(ls runtime_installer/*.install | head -n 1)
+          echo "Installing MATLAB Runtime from $INSTALLER"
+          
+          # Extract MATLAB version from installer filename
+          MATLAB_VER=$(basename "$INSTALLER" | sed -n 's/Runtime_\(R[0-9]\{4\}[ab]\)_for_spm_standalone\.install/\1/p')
+          echo "Detected MATLAB version: $MATLAB_VER"
+          echo "MATLAB_VERSION=$MATLAB_VER" >> $GITHUB_ENV
+          
+          # Install to /usr/local/MATLAB/MATLAB_Runtime
+          chmod +x "$INSTALLER"
+          sudo "$INSTALLER" -agreeToLicense yes -destinationFolder /usr/local/MATLAB/MATLAB_Runtime
+          
+          # Set environment variables
+          echo "LD_LIBRARY_PATH=/usr/local/MATLAB/MATLAB_Runtime/${MATLAB_VER}/runtime/glnxa64:/usr/local/MATLAB/MATLAB_Runtime/${MATLAB_VER}/bin/glnxa64:/usr/local/MATLAB/MATLAB_Runtime/${MATLAB_VER}/sys/os/glnxa64:/usr/local/MATLAB/MATLAB_Runtime/${MATLAB_VER}/sys/opengl/lib/glnxa64:/usr/local/MATLAB/MATLAB_Runtime/${MATLAB_VER}/extern/bin/glnxa64" >> $GITHUB_ENV
+          echo "MCR_INHIBIT_CTF_LOCK=1" >> $GITHUB_ENV
+          echo "SPM_HTML_BROWSER=0" >> $GITHUB_ENV
+          echo "MATLAB_RUNTIME_PATH=/usr/local/MATLAB/MATLAB_Runtime" >> $GITHUB_ENV
+
+      - name: Install MATLAB Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          INSTALLER=$(ls -d runtime_installer/*.app | head -n 1)
+          echo "Installing MATLAB Runtime from $INSTALLER"
+          
+          # Extract MATLAB version from installer filename
+          MATLAB_VER=$(basename "$INSTALLER" .app | sed -n 's/Runtime_\(R[0-9]\{4\}[ab]\)_for_spm_standalone/\1/p')
+          echo "Detected MATLAB version: $MATLAB_VER"
+          echo "MATLAB_VERSION=$MATLAB_VER" >> $GITHUB_ENV
+          
+          # Run installer
+          sudo "$INSTALLER/Contents/MacOS/setup" -agreeToLicense yes -destinationFolder "$HOME/MATLAB_Runtime" 2>&1 | tee install.log
+          
+          # Wait for installation to finish
+          sleep 2
+          
+          # Fix permissions (installer runs as sudo, files are owned by root)
+          sudo chown -R $USER "$HOME/MATLAB_Runtime"
+          sudo chown -R $USER "$HOME/.matlab" 2>/dev/null || true
+          
+          echo "MATLAB_RUNTIME_PATH=$HOME/MATLAB_Runtime/${MATLAB_VER}" >> $GITHUB_ENV
+          echo "✓ MATLAB Runtime installed at $HOME/MATLAB_Runtime/${MATLAB_VER}"
+
+      - name: Install MATLAB Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          INSTALLER=$(ls runtime_installer/*.exe | head -n 1)
+          echo "Installing MATLAB Runtime from $INSTALLER"
+          
+          # Extract MATLAB version from installer filename
+          MATLAB_VER=$(basename "$INSTALLER" .exe | sed -n 's/Runtime_\(R[0-9]\{4\}[ab]\)_for_spm_standalone/\1/p')
+          echo "Detected MATLAB version: $MATLAB_VER"
+          echo "MATLAB_VERSION=$MATLAB_VER" >> $GITHUB_ENV
+          
+          # Run installer
+          "$INSTALLER" -agreeToLicense yes -destinationFolder "C:\\MATLAB_Runtime"
+          echo "Installation command completed"
+          
+          # Add runtime to PATH and set environment variable
+          echo "C:\\MATLAB_Runtime\\${MATLAB_VER}\\runtime\\win64" >> $GITHUB_PATH
+          echo "MATLAB_RUNTIME_PATH=C:\\MATLAB_Runtime" >> $GITHUB_ENV
+          echo "✓ MATLAB Runtime installed successfully at C:\\MATLAB_Runtime"
+
+      # Download test data artifact (shared across all OS)
+      - name: Download test data artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-data
+          path: tests/data
+      
+      - name: Verify test data
+        shell: bash
+        run: |
+          if [ -d "tests/data" ]; then
+            echo "✓ Test data available from shared cache"
+            echo "Test data size: $(du -sh tests/data 2>/dev/null || echo 'unknown')"
+          else
+            echo "Error: Test data not found"
+            exit 1
+          fi
+
+      - name: Setup SPM standalone (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          # Detect SPM version
+          SPM_VERSION=$(ls spm_standalone/spm* 2>/dev/null | grep -E 'spm[0-9]+$' | head -n 1 | xargs basename | sed 's/spm//')
+          echo "Detected SPM version: $SPM_VERSION"
+          echo "SPM_VERSION=$SPM_VERSION" >> $GITHUB_ENV
+          
+          # Make executable and extract CTF archive
+          chmod +x "spm_standalone/spm${SPM_VERSION}"
+          echo "Extracting CTF archive..."
+          "spm_standalone/spm${SPM_VERSION}" function exit || true
+          
+          echo "SPM standalone setup complete"
+      
+      - name: Setup SPM standalone (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Detect SPM version
+          RUN_SCRIPT=$(ls spm_standalone/run_spm*.sh 2>/dev/null | head -n 1)
+          SPM_VERSION=$(basename "$RUN_SCRIPT" .sh | sed 's/run_spm//')
+          echo "Detected SPM version: $SPM_VERSION"
+          echo "SPM_VERSION=$SPM_VERSION" >> $GITHUB_ENV
+          
+          # Make script executable and extract CTF archive
+          chmod +x "spm_standalone/run_spm${SPM_VERSION}.sh"
+          echo "Extracting CTF archive..."
+          cd spm_standalone
+          ./run_spm${SPM_VERSION}.sh "$MATLAB_RUNTIME_PATH" function exit || true
+          cd ..
+          
+          echo "SPM standalone setup complete"
+      
+      - name: Setup SPM standalone (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # Detect SPM version
+          SPM_EXEC=$(ls spm_standalone/spm*.exe 2>/dev/null | head -n 1)
+          SPM_VERSION=$(basename "$SPM_EXEC" .exe | sed 's/spm//')
+          echo "Detected SPM version: $SPM_VERSION"
+          echo "SPM_VERSION=$SPM_VERSION" >> $GITHUB_ENV
+          
+          # Extract CTF archive
+          echo "Extracting CTF archive..."
+          cd spm_standalone
+          ./spm${SPM_VERSION}.exe function exit || true
+          cd ..
+          
+          echo "SPM standalone setup complete"
+      
+      - name: Copy test data to SPM location (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          TEST_DIR="spm_standalone/spm${SPM_VERSION}_mcr/spm${SPM_VERSION}/tests"
+          mkdir -p "$TEST_DIR"
+          cp -r tests/data "$TEST_DIR/"
+          chmod -R u+w "$TEST_DIR/data"
+          echo "Test data copied to $TEST_DIR/data"
+      
+      - name: Copy test data to SPM location (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          TEST_DIR="spm_standalone/spm${SPM_VERSION}.app/Contents/Resources/spm${SPM_VERSION}_mcr/spm${SPM_VERSION}/tests"
+          mkdir -p "$TEST_DIR"
+          cp -r tests/data "$TEST_DIR/"
+          chmod -R u+w "$TEST_DIR/data"
+          echo "Test data copied to $TEST_DIR/data"
+      
+      - name: Copy test data to SPM location (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          TEST_DIR="spm_standalone/spm${SPM_VERSION}_mcr/spm${SPM_VERSION}/tests"
+          mkdir -p "$TEST_DIR"
+          cp -r tests/data "$TEST_DIR/"
+          chmod -R u+w "$TEST_DIR/data"
+          echo "Test data copied to $TEST_DIR/data"
+      
+      - name: Test standalone (Linux)
+        if: runner.os == 'Linux'
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          cd spm_standalone
+          ./spm${SPM_VERSION} test
+
+      - name: Test standalone (macOS)
+        if: runner.os == 'macOS'
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          cd spm_standalone
+          ./run_spm${SPM_VERSION}.sh $MATLAB_RUNTIME_PATH test
+
+      - name: Test standalone (Windows)
+        if: runner.os == 'Windows'
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          cd spm_standalone
+          ./spm${SPM_VERSION}.exe test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{matrix.version}}
-          products: MATLAB_Compiler
+          products: |
+            MATLAB_Compiler
+            Signal_Processing_Toolbox
 
       - name: Extract MATLAB version to file
         uses: matlab-actions/run-command@v2
@@ -173,3 +175,13 @@ jobs:
               "spm_release": "${{ env.SPM_RELEASE }}",
               "spm_revision": "${{ env.SPM_REVISION }}"
             }
+
+  test_release_standalone:
+    name: Test Released Standalone
+    needs: build_matlab_standalone
+    if: always() && needs.build_matlab_standalone.result == 'success'
+    uses: ./.github/workflows/install_test_standalone.yml
+    secrets: inherit
+    with:
+      source: release
+      release_tag: ${{ github.ref_name }}

--- a/spm_standalone.m
+++ b/spm_standalone.m
@@ -61,6 +61,7 @@ switch lower(action)
             '    script         Execute a script\n',...
             '    function       Execute a function\n',...
             '    eval           Evaluate a MATLAB expression\n',...
+            '    test           Run the SPM test suite\n',...
             '    [NODE]         Run a specified batch node\n',...
             '\n',...
             'Options:\n',...
@@ -160,6 +161,38 @@ switch lower(action)
             eval(expr);
         catch
             exit_code = 1;
+        end
+        
+    case 'test'
+    %----------------------------------------------------------------------
+        spm_banner;
+        try
+            fprintf('Running SPM test suite...\n');
+            results = spm_tests();
+            
+            % Display summary
+            fprintf('\n=== Test Summary ===\n');
+            fprintf('Total tests: %d\n', numel(results));
+            fprintf('Passed: %d\n', sum([results.Passed]));
+            fprintf('Failed: %d\n', sum([results.Failed]));
+            fprintf('Incomplete: %d\n', sum([results.Incomplete]));
+            fprintf('Duration: %.2f seconds\n', sum([results.Duration]));
+            
+            % Set exit code based on actual failures (not incomplete tests)
+            num_failed = sum([results.Failed]);
+            if num_failed > 0
+                fprintf('\n=== Tests FAILED ===\n');
+                exit(1);
+            else
+                fprintf('\n=== All tests PASSED ===\n');
+                if sum([results.Incomplete]) > 0
+                    fprintf('(Incomplete/skipped tests are acceptable)\n');
+                end
+                exit(0);
+            end
+        catch ME
+            fprintf('Error running tests: %s\n', ME.message);
+            exit(1);
         end
         
     otherwise % cli

--- a/spm_tests.m
+++ b/spm_tests.m
@@ -85,7 +85,11 @@ else
 end
 
 if ~isempty(options.tag)
+    % Use the specified tag filter
     suite = suite.selectIf(~HasTag | HasTag(options.tag));
+else
+    % By default, exclude tests tagged as 'Disabled'
+    suite = suite.selectIf(~HasTag('Disabled'));
 end
 
 %-Create a TestRunner

--- a/tests/test_checkcode.m
+++ b/tests/test_checkcode.m
@@ -1,18 +1,20 @@
-function tests = test_checkcode
+classdef test_checkcode < matlab.unittest.TestCase
 % Test for possible problems in all of MATLAB code files
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 function test_display_matlab_version(testCase)
 % Output MATLAB version for reporting to Mathworks if needed
 ver -support
+end
 
 function test_checkcode_all(testCase)
 testCase.assumeTrue(strcmp(spm_check_version,'matlab'));
+testCase.assumeFalse(isdeployed);
 
 f = cellstr(spm_select('FPlistRec',spm('Dir'),'\.m$')); % discard external?
 s = checkcode(f,'-id');
@@ -29,9 +31,14 @@ if any(checked)
     fprintf('Problematic files are:\n');
     disp(f(checked));
 end
+end
+
+end % methods (Test)
 
 
-function t_e_s_t_analyzeCodeCompatibility(testCase) % disabled for now
+methods (Test, TestTags = {'Disabled'})
+
+function test_analyzeCodeCompatibility(testCase) % disabled for now
 testCase.assumeFalse(~strcmp(spm_check_version,'matlab') | ...
     spm_check_version('matlab','9.3') < 0);
     
@@ -43,3 +50,9 @@ for i=1:numel(idx)
     fprintf('%s:\n',r.Recommendations.File(idx(i)));
     fprintf('  %s\n',r.Recommendations.Description(idx(i)));
 end
+
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_gifti.m
+++ b/tests/test_gifti.m
@@ -1,11 +1,11 @@
-function tests = test_gifti
+classdef test_gifti < matlab.unittest.TestCase
 % Unit Tests for gifti
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_gifti_constructor(testCase)
@@ -38,7 +38,7 @@ testCase.verifyThat(struct(g4), IsEqualTo(s));
 
 testCase.verifyThat(g5, IsOfClass('gifti'));
 testCase.verifyThat(g5, HasField('cdata'));
-
+end
 
 function test_gifti_accessor(testCase)
 import matlab.unittest.constraints.*
@@ -55,7 +55,7 @@ g2 = gifti(cdata);
 testCase.verifyEqual(cdata,g2.cdata);
 testCase.verifyEqual(cdata(8),g2.cdata(8));
 testCase.verifyEqual(cdata(8,1),g2.cdata(8,1));
-
+end
 
 function test_gifti_mutator(testCase)
 import matlab.unittest.constraints.*
@@ -83,12 +83,13 @@ g.cdata = rand(size(g.vertices,1),1);
 g.cdata(1) = pi;
 g.cdata(2:end) = exp(1);
 testCase.verifyEqual(g.cdata(1), single(pi));
-
+end
 
 function test_gifti_export(testCase)
 import matlab.unittest.constraints.*
-mri = load('mri');
-g = gifti(isosurface(smooth3(squeeze(mri.D)),5));
+fn = fullfile(spm('Dir'),'canonical','single_subj_T1.nii');
+mri = uint8(256 * spm_read_vols(spm_vol(fn))); % scale from [0;1] to uint8 range
+g = gifti(isosurface(smooth3(mri),5));
 s = export(g);
 testCase.verifyThat(s, HasField('vertices'));
 testCase.verifyThat(s, HasField('faces'));
@@ -105,7 +106,7 @@ testCase.verifyThat(s, HasField('tri'));
 s = export(g,'spm');
 testCase.verifyThat(s, HasField('vert'));
 testCase.verifyThat(s, HasField('face'));
-
+end
 
 function test_gifti_load(testCase)
 import matlab.unittest.constraints.*
@@ -115,11 +116,13 @@ for i=1:numel(files)
     g = gifti(fullfile(d,files(i).name));
     testCase.verifyThat(evalc('g'), ~IsEmpty); % check display()
 end
+end
 
 
 function test_gifti_save(testCase)
-mri = load('mri');
-g = gifti(isosurface(smooth3(squeeze(mri.D)),5));
+fn = fullfile(spm('Dir'),'canonical','single_subj_T1.nii');
+mri = uint8(256 * spm_read_vols(spm_vol(fn))); % scale from [0;1] to uint8 range
+g = gifti(isosurface(smooth3(mri),5));
 g.cdata = rand(size(g.vertices,1),1);
 basename = tempname;
 file = [basename '.gii'];
@@ -154,3 +157,9 @@ for i=1:numel(encoding)
         end
     end
 end
+
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_regress_fmri_glm_dcm.m
+++ b/tests/test_regress_fmri_glm_dcm.m
@@ -1,4 +1,4 @@
-function tests = test_regress_fmri_glm_dcm
+classdef test_regress_fmri_glm_dcm < matlab.unittest.TestCase
 % Regression test for GLM and DCM for fMRI including timseries extraction
 % % This script analyses the Attention to Visual Motion fMRI dataset
 % available from the SPM website using DCM:
@@ -9,16 +9,15 @@ function tests = test_regress_fmri_glm_dcm
 
 % Copyright (C) 2024 Wellcome Centre for Human Neuroimaging
 
-tests = functiontests({@setup;
-                       @test_glm_parametric_volterra;
-                       @test_regress_glm_dcm});
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('Defaults','fMRI');
+        spm_jobman('initcfg');
+        spm_get_defaults('cmdline', true);
+    end
+end % methods (TestClassSetup)
 
-function setup(testCase)
-
-% Initialise SPM
-spm('Defaults','fMRI');
-spm_jobman('initcfg');
-spm_get_defaults('cmdline',true);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_glm_parametric_volterra(testCase)
@@ -32,12 +31,13 @@ options.volterra = true;
 options.pmod = true;
 
 % Specify and estimate GLM
-spm_setup_data_attention(data_path,options);
+test_regress_fmri_glm_dcm.specify_glm(data_path,options);
 
 % We expect 30 design matrix columns (9 first order, 21 second order)
 SPM = load(fullfile(data_path,'GLM','SPM.mat'));
 SPM = SPM.SPM;
 testCase.verifyTrue(size(SPM.xX.X,2)==30);
+end
 
 % -------------------------------------------------------------------------
 function test_regress_glm_dcm(testCase)
@@ -45,14 +45,149 @@ function test_regress_glm_dcm(testCase)
 
 data_path = fullfile(spm('Dir'),'tests','data','attention');
 
-% Specify and estimate GLM, extract timeseries and run DCM
-options.dcm = true;
-spm_setup_data_attention(data_path,options);
+% Specify and estimate GLM
+test_regress_fmri_glm_dcm.specify_glm(data_path);
 
-% Load estimated DCM and BMR results
-results = load(fullfile(data_path,'GCM_test.mat'));
-GCM  = results.GCM;
-post = results.post;
+clear matlabbatch
+
+% EXTRACTING TIME SERIES: V5
+matlabbatch{1}.spm.util.voi.spmmat = cellstr(fullfile(data_path,'GLM','SPM.mat'));
+matlabbatch{1}.spm.util.voi.adjust = 1;  % "effects of interest" F-contrast
+matlabbatch{1}.spm.util.voi.session = 1; % session 1
+matlabbatch{1}.spm.util.voi.name = 'V5';
+matlabbatch{1}.spm.util.voi.roi{1}.spm.spmmat = {''}; % using SPM.mat above
+matlabbatch{1}.spm.util.voi.roi{1}.spm.contrast = 3;  % "Motion" T-contrast
+matlabbatch{1}.spm.util.voi.roi{1}.spm.threshdesc = 'FWE';
+matlabbatch{1}.spm.util.voi.roi{1}.spm.thresh = 0.05;
+matlabbatch{1}.spm.util.voi.roi{1}.spm.extent = 0;
+matlabbatch{1}.spm.util.voi.roi{1}.spm.mask.contrast = 4; % "Attention" T-contrast
+matlabbatch{1}.spm.util.voi.roi{1}.spm.mask.thresh = 0.05;
+matlabbatch{1}.spm.util.voi.roi{1}.spm.mask.mtype = 0; % inclusive
+matlabbatch{1}.spm.util.voi.roi{2}.sphere.centre = [-36 -87 -3];
+matlabbatch{1}.spm.util.voi.roi{2}.sphere.radius = 8;
+matlabbatch{1}.spm.util.voi.roi{2}.sphere.move.fixed = 1;
+matlabbatch{1}.spm.util.voi.expression = 'i1 & i2';
+
+% EXTRACTING TIME SERIES: V1
+matlabbatch{2}.spm.util.voi.spmmat = cellstr(fullfile(data_path,'GLM','SPM.mat'));
+matlabbatch{2}.spm.util.voi.adjust = 1;  % "effects of interest" F-contrast
+matlabbatch{2}.spm.util.voi.session = 1; % session 1
+matlabbatch{2}.spm.util.voi.name = 'V1';
+matlabbatch{2}.spm.util.voi.roi{1}.spm.spmmat = {''}; % using SPM.mat above
+matlabbatch{2}.spm.util.voi.roi{1}.spm.contrast = 2;  % "Photic" T-contrast
+matlabbatch{2}.spm.util.voi.roi{1}.spm.threshdesc = 'FWE';
+matlabbatch{2}.spm.util.voi.roi{1}.spm.thresh = 0.05;
+matlabbatch{2}.spm.util.voi.roi{1}.spm.extent = 0;
+matlabbatch{2}.spm.util.voi.roi{2}.sphere.centre = [0 -93 18];
+matlabbatch{2}.spm.util.voi.roi{2}.sphere.radius = 8;
+matlabbatch{2}.spm.util.voi.roi{2}.sphere.move.fixed = 1;
+matlabbatch{2}.spm.util.voi.expression = 'i1 & i2';
+
+% EXTRACTING TIME SERIES: SPC
+matlabbatch{3}.spm.util.voi.spmmat = cellstr(fullfile(data_path,'GLM','SPM.mat'));
+matlabbatch{3}.spm.util.voi.adjust = 1;  % "effects of interest" F-contrast
+matlabbatch{3}.spm.util.voi.session = 1; % session 1
+matlabbatch{3}.spm.util.voi.name = 'SPC';
+matlabbatch{3}.spm.util.voi.roi{1}.spm.spmmat = {''}; % using SPM.mat above
+matlabbatch{3}.spm.util.voi.roi{1}.spm.contrast = 4;  % "Attention" T-contrast
+matlabbatch{3}.spm.util.voi.roi{1}.spm.threshdesc = 'none';
+matlabbatch{3}.spm.util.voi.roi{1}.spm.thresh = 0.001;
+matlabbatch{3}.spm.util.voi.roi{1}.spm.extent = 0;
+matlabbatch{3}.spm.util.voi.roi{2}.sphere.centre = [-27 -84 36];
+matlabbatch{3}.spm.util.voi.roi{2}.sphere.radius = 8;
+matlabbatch{3}.spm.util.voi.roi{2}.sphere.move.fixed = 1;
+matlabbatch{3}.spm.util.voi.expression = 'i1 & i2';
+
+spm_jobman('run',matlabbatch);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% DYNAMIC CAUSAL MODELLING
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Select SPM.mat
+spm_file = fullfile(data_path,'GLM','SPM.mat');
+
+% Select VOIs
+xY = cell(3,1);
+xY{1} = fullfile(data_path,'GLM','VOI_V1_1.mat');
+xY{2} = fullfile(data_path,'GLM','VOI_V5_1.mat');
+xY{3} = fullfile(data_path,'GLM','VOI_SPC_1.mat');
+
+% Indices of the brain regions in the model
+V1  = 1; 
+V5  = 2;
+SPC = 3;
+
+% DCM settings
+n   = 3;    % number of regions
+nu  = 3;    % number of inputs (experimental conditions)
+TR  = 3.22; % volume repetition time (seconds)
+TE  = 0.04; % echo time (seconds)
+
+% Experimental conditions to include from the SPM.
+cond = struct();
+cond(1).name = 'Photic';
+cond(2).name = 'Motion';
+cond(3).name = 'Attention';
+
+% Indices of the conditions in the model
+PHOTIC = 1;
+MOTION = 2;
+ATTENTION = 3;
+
+% Connectivity matrices
+a  = ones(n,n);
+b  = zeros(n,n,nu);
+c  = zeros(n,nu);
+d  = zeros(n,n,0);
+
+% A-matrix connectivity
+a(V1,SPC) = 0; % SPC->V1
+a(SPC,V1) = 0; % V1->SPC
+
+% Modulatory input: motion on V1->V5
+b(V5,V1,MOTION) = 1;
+
+% Driving input: photic
+c(V1,PHOTIC) = 1;
+
+% DCM options
+s = struct();
+s.cond       = cond;
+s.delays     = repmat(TR/2, 1, n);
+s.TE         = TE;
+s.nonlinear  = false;
+s.two_state  = false;
+s.stochastic = false;
+s.centre     = true;
+s.induced    = 0;
+s.a          = a;
+s.b          = b;
+s.c          = c;
+s.d          = d;
+
+% Cell array to store DCMs [1 subject x 2 models]
+GCM = cell(1,2);
+
+% Specify model 1: forward model, with attention on V1->V5
+s.name = 'mod_fwd';
+s.b(V5,V1,ATTENTION) = 1;
+GCM{1,1} = spm_dcm_specify(spm_file,xY,s);
+
+% Specify model 2: backward model, with attention on SPC->V5
+s.name = 'mod_bwd';
+s.b = b;
+s.b(V5,SPC,ATTENTION);
+GCM{1,2} = spm_dcm_specify(spm_file,xY,s);
+
+% Suppress output
+spm_get_defaults('dcm.verbose',false);
+
+% Estimate the models
+GCM = spm_dcm_fit(GCM);
+
+% Bayesian model comparison
+post = spm_dcm_bmc(GCM);
 
 % Get the explained variance
 DCM = spm_dcm_fmri_check(GCM{1},true);
@@ -67,3 +202,89 @@ testCase.verifyTrue(exp_var > 75);
 
 % Check the largest neural connection was non-trivial (> 0.5Hz)
 testCase.verifyTrue(max_connection > 0.5);
+end
+
+end % methods (Test)
+
+
+% Helper methods
+methods (Static, Access = private)
+    
+% -------------------------------------------------------------------------
+function specify_glm(data_path,options)
+% GLM SPECIFICATION, ESTIMATION & INFERENCE
+
+if nargin == 1
+    options = struct('pmod',false,'bf',1,'volterra',false);
+end
+
+spm_dir = fullfile(data_path,'GLM');
+spm_mat = fullfile(spm_dir,'SPM.mat');
+if exist(spm_dir,'file') && exist(spm_mat,'file')
+    delete(spm_mat);
+end
+
+factors = load(fullfile(data_path,'factors.mat'));
+
+f = spm_select('FPList', fullfile(data_path,'functional'), '^snf.*\.img$');
+
+clear matlabbatch
+
+% OUTPUT DIRECTORY
+matlabbatch{1}.cfg_basicio.file_dir.dir_ops.cfg_mkdir.parent = cellstr(data_path);
+matlabbatch{1}.cfg_basicio.file_dir.dir_ops.cfg_mkdir.name = 'GLM';
+
+% MODEL SPECIFICATION
+matlabbatch{2}.spm.stats.fmri_spec.dir = cellstr(fullfile(data_path,'GLM'));
+matlabbatch{2}.spm.stats.fmri_spec.timing.units = 'scans';
+matlabbatch{2}.spm.stats.fmri_spec.timing.RT    = 3.22;
+matlabbatch{2}.spm.stats.fmri_spec.sess.scans            = cellstr(f);
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).name     = 'Photic';
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).onset    = [factors.phot];
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).duration = 10;
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(2).name     = 'Motion';
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(2).onset    = [factors.mot];
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(2).duration = 10;
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(3).name     = 'Attention';
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(3).onset    = [factors.att];
+matlabbatch{2}.spm.stats.fmri_spec.sess.cond(3).duration = 10;
+
+if options.pmod == true
+    % Add random parametric regressor to condition 1
+    rng(1);
+    p = randn(20,1);
+    matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).pmod.name = 'pmod';
+    matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).pmod.param = p;
+    matlabbatch{2}.spm.stats.fmri_spec.sess.cond(1).pmod.poly = 1;
+end
+    
+if options.bf == 2
+    % Add time derivative
+    matlabbatch{2}.spm.stats.fmri_spec.bases.hrf.derivs = [1 0];
+end
+
+if options.volterra == true
+    % Add interaction terms for estimating volterra kernels
+    matlabbatch{2}.spm.stats.fmri_spec.volt = 2;
+end
+
+% MODEL ESTIMATION
+matlabbatch{3}.spm.stats.fmri_est.spmmat = cellstr(fullfile(data_path,'GLM','SPM.mat'));
+
+% INFERENCE
+matlabbatch{4}.spm.stats.con.spmmat = cellstr(fullfile(data_path,'GLM','SPM.mat'));
+matlabbatch{4}.spm.stats.con.consess{1}.fcon.name = 'Effects of Interest';
+matlabbatch{4}.spm.stats.con.consess{1}.fcon.weights = eye(3);
+matlabbatch{4}.spm.stats.con.consess{2}.tcon.name = 'Photic';
+matlabbatch{4}.spm.stats.con.consess{2}.tcon.weights = [1 0 0];
+matlabbatch{4}.spm.stats.con.consess{3}.tcon.name = 'Motion';
+matlabbatch{4}.spm.stats.con.consess{3}.tcon.weights = [0 1 0];
+matlabbatch{4}.spm.stats.con.consess{4}.tcon.name = 'Attention';
+matlabbatch{4}.spm.stats.con.consess{4}.tcon.weights = [0 0 1];
+
+spm_jobman('run',matlabbatch);
+end
+
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_regress_fmri_group.m
+++ b/tests/test_regress_fmri_group.m
@@ -1,57 +1,59 @@
-function tests = test_regress_fmri_group
+classdef test_regress_fmri_group < matlab.unittest.TestCase
 % Regression tests for second-level SPM for fMRI
 
-% Manual specification of tests to run
-tests = functiontests({@setup;
-                       @test_regress_onesample_ttest_classical;
-                       @test_regress_twosample_ttest_classical;
-                       @test_regress_flex_factorial_classical;
-                       @test_regress_flex_factorial_bayesian});
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('defaults','fmri');
+        spm_jobman('initcfg');
+        spm_get_defaults('cmdline',true);
+    end
+end % methods (TestClassSetup)
 
-% -------------------------------------------------------------------------
-function setup(testCase) 
-
-% Start SPM
-spm('defaults','fmri');
-spm_jobman('initcfg');
-spm_get_defaults('cmdline',true);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_regress_onesample_ttest_classical(testCase)
 
-xyz_mm = run_onesample_ttest(false);
+xyz_mm = test_regress_fmri_group.run_onesample_ttest(false);
 
 % Check the global peak hasn't moved (3mm tolerance)
 tol = [3 3 3]';
 testCase.assertEqual(xyz_mm,[42 -82 -6]','AbsTol', tol);
+end
 
 % -------------------------------------------------------------------------
 function test_regress_twosample_ttest_classical(testCase)
 
-xyz_mm = run_twosample_ttest(false);
+xyz_mm = test_regress_fmri_group.run_twosample_ttest(false);
 
 % Check the global peak hasn't moved (3mm tolerance)
 tol = [3 3 3]';
 testCase.assertEqual(xyz_mm,[40 -22 52]','AbsTol', tol);
+end
 
 % -------------------------------------------------------------------------
 function test_regress_flex_factorial_classical(testCase)
 
-xyz_mm = run_flex_factorial(false);
+xyz_mm = test_regress_fmri_group.run_flex_factorial(false);
 
 % Check the global peak hasn't moved (3mm tolerance)
 tol = [3 3 3]';
 testCase.assertEqual(xyz_mm,[40 -22 52]','AbsTol', tol);
+end
 
 % -------------------------------------------------------------------------
 function test_regress_flex_factorial_bayesian(testCase)
 
-xyz_mm = run_flex_factorial(true);
+xyz_mm = test_regress_fmri_group.run_flex_factorial(true);
 
 % Check the global peak hasn't moved (3mm tolerance)
 tol = [3 3 3]';
 testCase.assertEqual(xyz_mm,[40 -22 52]','AbsTol', tol);
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function xyz_mm = run_onesample_ttest(bayesian)
 % Run a second level one sample t-test on fMRI data and get the global peak
@@ -116,7 +118,8 @@ matlabbatch{1}.spm.stats.con.consess{1}.tcon.sessrep = 'none';
 matlabbatch{1}.spm.stats.con.delete = 1;
 spm_jobman('run',matlabbatch);
 
-xyz_mm = get_global_peak(level2_dir,bayesian);
+xyz_mm = test_regress_fmri_group.get_global_peak(level2_dir,bayesian);
+end
 
 % -------------------------------------------------------------------------
 function xyz_mm = run_twosample_ttest(bayesian)
@@ -196,7 +199,8 @@ matlabbatch{1}.spm.stats.con.consess{1}.tcon.sessrep = 'none';
 matlabbatch{1}.spm.stats.con.delete = 1;
 spm_jobman('run',matlabbatch);
 
-xyz_mm = get_global_peak(level2_dir,bayesian);
+xyz_mm = test_regress_fmri_group.get_global_peak(level2_dir,bayesian);
+end
 
 % -------------------------------------------------------------------------
 function xyz_mm = run_flex_factorial(bayesian)
@@ -294,7 +298,8 @@ matlabbatch{1}.spm.stats.con.consess{1}.tcon.sessrep = 'none';
 matlabbatch{1}.spm.stats.con.delete = 1;
 spm_jobman('run',matlabbatch);
 
-xyz_mm = get_global_peak(level2_dir,bayesian);
+xyz_mm = test_regress_fmri_group.get_global_peak(level2_dir,bayesian);
+end
 
 % -------------------------------------------------------------------------
 function xyz_mm = get_global_peak(spm_dir,bayesian)
@@ -331,6 +336,7 @@ else
     % Get the global peak from the SPM results table
     xyz_mm = out{1}.TabDatvar.dat{1,end};
 end
+end
 
 % -------------------------------------------------------------------------
 % function test_timing_twosample_ttest(testCase)
@@ -357,3 +363,7 @@ end
 % 
 % % Run 3. No parallelisation:
 % % median 97.29 seconds [98.1365   97.2127   97.2867]
+% end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_regress_spm_opm.m
+++ b/tests/test_regress_spm_opm.m
@@ -1,15 +1,19 @@
-function tests = test_regress_spm_opm
+classdef test_regress_spm_opm < matlab.unittest.TestCase
 % regresion test for OPM functions
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('defaults','eeg');
+    end
+end % methods (TestClassSetup)
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_regress_spm_opm_1(testCase)
-spm('defaults','eeg');
 
 data = fullfile(spm('Dir'),'tests','data','OPM','OPM_meg_001.cMEG');
 positions = fullfile(spm('Dir'),'tests','data','OPM','OPM_HelmConfig.tsv');
@@ -77,3 +81,8 @@ delete(muD);
 peakValInRange = max(abs(pl(:))) < 154.6222 &  max(abs(pl(:))) > 154.3132;
 
 testCase.verifyTrue(peakValInRange);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm.m
+++ b/tests/test_spm.m
@@ -1,11 +1,12 @@
-function tests = test_spm
+classdef test_spm < matlab.unittest.TestCase
 % Unit Tests for spm
 %__________________________________________________________________________
 
 % Copyright (C) 2021-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_multi(testCase)
@@ -37,3 +38,9 @@ mem_avail = spm('Memory','available');
 testCase.verifyThat(mem_avail, IsOfClass('double'));
 mem_total = spm('Memory','total');
 testCase.verifyThat(mem_total, IsOfClass('double'));
+
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_BMS_gibbs.m
+++ b/tests/test_spm_BMS_gibbs.m
@@ -1,11 +1,11 @@
-function tests = test_spm_BMS_gibbs
+classdef test_spm_BMS_gibbs < matlab.unittest.TestCase
 % Unit Tests for spm_BMS_gibbs
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_strong_evidence(testCase)
@@ -51,3 +51,8 @@ testCase.verifyThat(actual, IsEqualTo(r, 'Within', AbsoluteTolerance(0.1) ) );
 % Check exceedance probability
 actual = xp(1);
 testCase.verifyThat(actual, IsGreaterThanOrEqualTo(0.95) );
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_Ce.m
+++ b/tests/test_spm_Ce.m
@@ -1,11 +1,11 @@
-function tests = test_spm_Ce
+classdef test_spm_Ce < matlab.unittest.TestCase
 % Unit Tests for spm_Ce
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_Ce_1(testCase)
@@ -23,7 +23,7 @@ testCase.verifyThat(C, IsEqualTo(spm_Ce(N)));
 
 C = spm_Ce(N,0.2);
 testCase.verifyThat(C, HasLength(2*numel(N)));
-
+end
 
 function test_spm_Ce_2(testCase)
 import matlab.unittest.constraints.*
@@ -36,7 +36,7 @@ testCase.verifyThat(C, IsEqualTo(spm_Ce(N,[])));
 
 C = spm_Ce('ar',N,0.4);
 testCase.verifyThat(C, IsEqualTo(spm_Ce(N,0.4)));
-
+end
 
 function test_spm_Ce_3(testCase)
 import matlab.unittest.constraints.*
@@ -45,3 +45,8 @@ testCase.verifyThat(C, IsOfClass('cell'));
 
 C = spm_Ce('fast',[16 32],3);
 testCase.verifyThat(C, IsOfClass('cell'));
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_Ncdf.m
+++ b/tests/test_spm_Ncdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_Ncdf
+classdef test_spm_Ncdf < matlab.unittest.TestCase
 % Unit Tests for spm_Ncdf
 %__________________________________________________________________________
 
 % Copyright (C) 2019-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_Ncdf_1(testCase)
@@ -13,36 +14,42 @@ exp = 0.5; % normcdf(0,0,1)
 act = spm_Ncdf(0,0,1);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_2(testCase)
 exp = 0.5; % normcdf(0,0,4)
 act = spm_Ncdf(0,0,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_3(testCase)
 exp = 0.158655253931457; % normcdf(0,2,sqrt(4))
 act = spm_Ncdf(0,2,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_4(testCase)
 exp = 0.001349898031630; % normcdf(-4,2,sqrt(4))
 act = spm_Ncdf(-4,2,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_5(testCase)
 exp = 0.933192798731142; % normcdf(5,2,sqrt(4))
 act = spm_Ncdf(5,2,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_6(testCase)
 exp = 0.999968328758167; % normcdf(10,2,sqrt(4))
 act = spm_Ncdf(10,2,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_Ncdf_7(testCase)
 exp = [0.000173309675567  % normcdf(-4:10,4,sqrt(5))
@@ -63,3 +70,7 @@ exp = [0.000173309675567  % normcdf(-4:10,4,sqrt(5))
 act = spm_Ncdf(-4:10,4,5);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_bireduce.m
+++ b/tests/test_spm_bireduce.m
@@ -1,10 +1,10 @@
-function tests = test_spm_bireduce
+classdef test_spm_bireduce < matlab.unittest.TestCase
 % Unit Tests for test_spm_bireduce
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2024 Wellcome Centre for Human Neuroimaging
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_bireduce(testCase)
@@ -27,3 +27,8 @@ M.l  = 2;                       % number of outputs
 
 % Verify spm_bireduce runs without warnings
 testCase.verifyWarningFree(@() spm_bireduce(M,M.pE));
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_cat_struct.m
+++ b/tests/test_spm_cat_struct.m
@@ -1,11 +1,11 @@
-function tests = test_spm_cat_struct
+classdef test_spm_cat_struct < matlab.unittest.TestCase
 % Unit Tests for spm_cat_struct
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_cat_struct_1(testCase)
@@ -15,6 +15,7 @@ s2 = struct('a',3,'b',4);
 exp = struct('a',{1,3},'b',{2,4});
 act = spm_cat_struct(s1,s2);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_cat_struct_2(testCase)
 s1 = struct('a',1);
@@ -23,6 +24,7 @@ s2 = struct('b',2);
 exp = struct('a',{1,[]},'b',{[],2});
 act = spm_cat_struct(s1,s2);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_cat_struct_3(testCase)
 s1 = struct('a',{1,2});
@@ -35,6 +37,7 @@ testCase.verifyEqual(act, exp);
 exp = struct('a',{[],1,2},'b',{3,[],[]});
 act = spm_cat_struct(s2,s1);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_cat_struct_4(testCase)
 s1 = struct('a',{1;2});
@@ -47,6 +50,7 @@ testCase.verifyEqual(act, exp);
 exp = struct('a',{[],1,2},'b',{3,[],[]});
 act = spm_cat_struct(s2,s1);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_cat_struct_5(testCase)
 s1 = struct('a',{1,2});
@@ -56,6 +60,7 @@ s3 = struct('a',4,'c',5);
 exp = struct('a',{1,2,[],4},'b',{[],[],3,[]},'c',{[],[],[],5});
 act = spm_cat_struct(s1,s2,s3);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_cat_struct_6(testCase)
 s1 = struct('a',{1,2;3 4},'b',{5,6;7,8});
@@ -64,3 +69,8 @@ s2 = struct('b',{0,1},'c',{3,2});
 exp = struct('a',{1,3,2,4,[],[]},'b',{5,7,6,8,0,1},'c',{[],[],[],[],3,2})';
 act = spm_cat_struct(s1,s2);
 testCase.verifyEqual(act, exp);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_cfg_dcm_est.m
+++ b/tests/test_spm_cfg_dcm_est.m
@@ -1,33 +1,33 @@
-function tests = test_spm_cfg_dcm_est
+classdef test_spm_cfg_dcm_est < matlab.unittest.TestCase
 % Unit Tests for test_spm_cfg_dcm_est (DCM model estimation batch)
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        [input_path, path] = test_spm_cfg_dcm_est.prepare_paths(0);
 
-tests = functiontests(localfunctions);
+        % Paths to delete
+        paths = {fullfile(path,'tmp'); path};
 
-% -------------------------------------------------------------------------
-function setup(testCase)
-% Delete output directory before each test
-[input_path, path] = prepare_paths(0);
-
-% Paths to delete
-paths = {fullfile(path,'tmp'); path};
-
-for p = 1:length(paths)
-    if exist(paths{p},'file')
-        delete(fullfile(paths{p},'*.mat'));
-        rmdir(paths{p});
+        for p = 1:length(paths)
+            if exist(paths{p},'file')
+                delete(fullfile(paths{p},'*.mat'));
+                rmdir(paths{p});
+            end
+        end
     end
-end
+end % methods (TestClassSetup)
+
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_select_by_gcm(testCase)
 % Test selecting a group DCM file (GCM)
 
 % Prepare paths
-[input_path, path] = prepare_paths();
+[input_path, path] = test_spm_cfg_dcm_est.prepare_paths();
 
 % Expected output
 expected = fullfile(path,'GCM_test.mat');
@@ -49,14 +49,15 @@ testCase.assertEqual(actual,expected);
 testCase.assertTrue(exist(expected,'file') > 0);
 
 % Check output contents is correct
-assert_gcms_match(actual,gcm_file,testCase);
+test_spm_cfg_dcm_est.assert_gcms_match(actual,gcm_file,testCase);
+end
 
 % -------------------------------------------------------------------------
 function test_select_by_model(testCase)
 % Test selecting DCMs model-by-model
 
 % Prepare paths
-[input_path, path] = prepare_paths();
+[input_path, path] = test_spm_cfg_dcm_est.prepare_paths();
 
 % Expected output
 expected = fullfile(path,'GCM_test.mat');
@@ -88,14 +89,15 @@ testCase.assertTrue(exist(expected,'file') > 0);
 
 % Check output contents is correct
 gcm_file = fullfile(input_path,'GCM_simulated.mat'); 
-assert_gcms_match(actual,gcm_file,testCase);
+test_spm_cfg_dcm_est.assert_gcms_match(actual,gcm_file,testCase);
+end
 
 % -------------------------------------------------------------------------
 function test_select_by_subject(testCase)
 % Test selecting DCMs subject-by-subject
 
 % Prepare paths
-[input_path, path] = prepare_paths();
+[input_path, path] = test_spm_cfg_dcm_est.prepare_paths();
 
 % Expected output
 expected = fullfile(path,'GCM_test.mat');
@@ -124,14 +126,15 @@ testCase.assertTrue(exist(expected,'file') > 0);
 
 % Check output contents is correct
 gcm_file = fullfile(input_path,'GCM_simulated.mat'); 
-assert_gcms_match(actual,gcm_file,testCase);
+test_spm_cfg_dcm_est.assert_gcms_match(actual,gcm_file,testCase);
+end
 
 % -------------------------------------------------------------------------
 function test_separate_dcm_output(testCase)
 % Test that outputting separate DCMs gives the correct results
 
 % Prepare paths
-[input_path, path] = prepare_paths();
+[input_path, path] = test_spm_cfg_dcm_est.prepare_paths();
 
 % Copy all DCMs into a temporary folder
 tmp_path = fullfile(path, 'tmp');
@@ -163,13 +166,18 @@ testCase.assertEqual(actual,expected);
 % Check output contents is correct
 gcm_file = fullfile(input_path,'GCM_simulated.mat'); 
 GCM = spm_dcm_load(gcm_file);
-assert_gcms_match(actual,GCM(:,1),testCase);
+test_spm_cfg_dcm_est.assert_gcms_match(actual,GCM(:,1),testCase);
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
 
 % -------------------------------------------------------------------------
 function [input_path, path] = prepare_paths(do_create)
@@ -179,13 +187,15 @@ if nargin < 1
     do_create = 1;
 end
 
-data_path   = get_data_path();
+data_path   = test_spm_cfg_dcm_est.get_data_path();
 input_path  = fullfile(data_path,'models');
 path = fullfile(data_path,'out');
 
 if do_create && ~exist(path,'file')
     mkdir(path);
 end
+end
+
 % -------------------------------------------------------------------------
 function assert_gcms_match(actual,expected,testCase)
 % Check that two GCM cell arrays match in terms of contents
@@ -217,3 +227,7 @@ for m = 1:nm
     testCase.assertEqual(actual_id,expected_id,...
         'AbsTol',0.001,sprintf('GCM index %d doesn''t match',m));
 end
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_cfg_dcm_fmri.m
+++ b/tests/test_spm_cfg_dcm_fmri.m
@@ -1,34 +1,34 @@
-function tests = test_spm_cfg_dcm_fmri
+classdef test_spm_cfg_dcm_fmri < matlab.unittest.TestCase
 % Unit Tests for spm_cfg_dcm_fmri (DCM fMRI spec batch)
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        % Delete artefacts before each test
 
-tests = functiontests(localfunctions);
+        % Delete GCM from the tmp directory
+        outpath = fullfile(test_spm_cfg_dcm_fmri.get_data_path(), 'tmp');
+        if exist(outpath,'file')
+            delete(fullfile(outpath,'*.mat'));
+        end
 
+        % Delete DCMs from the GLM directory
+        glmdir = fullfile(test_spm_cfg_dcm_fmri.get_data_path(), 'GLM');
+        dcms   = cellstr(spm_select('FPListRec',glmdir,'^DCM_.*mat$'));
+        for i = 1:length(dcms)
+            spm_unlink(dcms{i});
+        end
+    end
+end % methods (TestClassSetup)
 
-% -------------------------------------------------------------------------
-function setup(testCase)
-% Delete artefacts before each test
-
-% Delete GCM from the tmp directory
-outpath = fullfile(get_data_path(), 'tmp');
-if exist(outpath,'file')
-    delete(fullfile(outpath,'*.mat'));
-end
-
-% Delete DCMs from the GLM directory
-glmdir = fullfile(get_data_path(), 'GLM');
-dcms   = cellstr(spm_select('FPListRec',glmdir,'^DCM_.*mat$'));
-for i = 1:length(dcms)
-    spm_unlink(dcms{i});
-end
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_specify_group(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_fmri.get_data_path();
 
 % Output path & directory
 outpath = fullfile(data_path, 'tmp');
@@ -80,9 +80,17 @@ for s = 1:size(GCM,1)
             sprintf('Timeseries for subject %d model %m wrong',s,m));
     end
 end
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_cfg_dcm_peb.m
+++ b/tests/test_spm_cfg_dcm_peb.m
@@ -1,40 +1,41 @@
-function tests = test_spm_cfg_dcm_peb
+classdef test_spm_cfg_dcm_peb < matlab.unittest.TestCase
 % Unit Tests for spm_cfg_dcm_peb (PEB batch)
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        % Initialize SPM
+        spm('defaults','fmri');
+        spm_jobman('initcfg');
+        spm_get_defaults('cmdline',true);
+        spm_get_defaults('dcm.verbose',false);
 
-tests = functiontests(localfunctions);
+        % Delete artefacts before each test
+        model_dir = fullfile(test_spm_cfg_dcm_peb.get_data_path(),'models');
+        expected_output = {fullfile(model_dir,'PEB_test.mat');
+                        fullfile(model_dir,'BMA_PEB_test.mat');
+                        fullfile(model_dir,'LOO_test.mat');
+                        fullfile(model_dir,'GCM_simulated_abridged.mat')};
 
-% -------------------------------------------------------------------------
-function setup(testCase)
-
-% Initialize SPM
-spm('defaults','fmri');
-spm_jobman('initcfg');
-spm_get_defaults('cmdline',true);
-spm_get_defaults('dcm.verbose',false);
-
-% Delete artefacts before each test
-model_dir = fullfile(get_data_path(),'models');
-expected_output = {fullfile(model_dir,'PEB_test.mat');
-                   fullfile(model_dir,'BMA_PEB_test.mat');
-                   fullfile(model_dir,'LOO_test.mat');
-                   fullfile(model_dir,'GCM_simulated_abridged.mat')};
-
-for i = 1:length(expected_output)
-    if exist(expected_output{i},'file')
-        spm_unlink(expected_output{i});
+        for i = 1:length(expected_output)
+            if exist(expected_output{i},'file')
+                spm_unlink(expected_output{i});
+            end
+        end
     end
-end
+end % methods (TestClassSetup)
+
+
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_specify_peb(testCase)
 % Test specifying & estimating a PEB model
 
 % Prepare paths
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_peb.get_data_path();
 model_dir = fullfile(data_path,'models');
 X_file    = fullfile(data_path,'design_matrix.mat');
 GCM_file  = fullfile(model_dir,'GCM_simulated.mat');
@@ -81,13 +82,14 @@ testCase.assertEqual(size(PEB.Ep,2), expected_covariates);
 testCase.assertEqual(size(PEB.Snames,1), expected_subjects);
 testCase.assertEqual(PEB.M.hE, repmat(hE,np,1));
 testCase.assertEqual(PEB.M.hC, diag(repmat(hC,np,1)));
+end
 
 % -------------------------------------------------------------------------
 function test_specify_peb_precision_options(testCase)
 % Test specifying & estimating a PEB model
 
 % Prepare paths
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_peb.get_data_path();
 model_dir = fullfile(data_path,'models');
 X_file    = fullfile(data_path,'design_matrix.mat');
 GCM_file  = fullfile(model_dir,'GCM_simulated.mat');
@@ -150,12 +152,13 @@ spm_jobman('run',matlabbatch);
 PEB = load(expected_output);
 PEB = PEB.PEB;
 testCase.assertFalse(isfield(PEB.M,'Q'));
+end
 
 % -------------------------------------------------------------------------
 function test_compare_models(testCase)
 
 % Prepare paths
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_peb.get_data_path();
 model_dir = fullfile(data_path,'models');
 X_file    = fullfile(data_path,'design_matrix.mat');
 GCM_file  = fullfile(model_dir,'GCM_simulated.mat');
@@ -200,11 +203,13 @@ expected_output = fullfile(model_dir,'BMA_PEB_test.mat');
 testCase.assertTrue(exist(expected_output,'file') > 0);
 
 close all;
+end
+
 % -------------------------------------------------------------------------
 function test_search_reduced_models(testCase)
 
 % Prepare paths
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_peb.get_data_path();
 model_dir = fullfile(data_path,'models');
 X_file    = fullfile(data_path,'design_matrix.mat');
 GCM_file  = fullfile(model_dir,'GCM_simulated.mat');
@@ -249,11 +254,13 @@ expected_output = fullfile(model_dir,'BMA_search_PEB_test.mat');
 testCase.assertTrue(exist(expected_output,'file') > 0);
 
 close all;
+end
+
 % -------------------------------------------------------------------------
 function test_loo(testCase)
 
 % Prepare paths
-data_path = get_data_path();
+data_path = test_spm_cfg_dcm_peb.get_data_path();
 model_dir = fullfile(data_path,'models');
 X_file    = fullfile(data_path,'design_matrix.mat');
 GCM_file  = fullfile(model_dir,'GCM_simulated.mat');
@@ -294,8 +301,17 @@ expected_output = fullfile(model_dir,'LOO_test.mat');
 testCase.assertTrue(exist(expected_output,'file') > 0);
 
 close all;
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_create_vol.m
+++ b/tests/test_spm_create_vol.m
@@ -1,11 +1,11 @@
-function tests = test_spm_create_vol
+classdef test_spm_create_vol < matlab.unittest.TestCase
 % Unit Tests for spm_create_vol
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_create_vol_hdr(testCase)
@@ -21,6 +21,7 @@ V = spm_create_vol(V);
 hdrfile = spm_file(V.fname,'ext','.hdr');
 testCase.verifyEqual(exist(hdrfile,'file'),2);
 spm_unlink(hdrfile);
+end
 
 function test_spm_create_vol_nii(testCase)
 V = struct(...
@@ -34,6 +35,7 @@ V = struct(...
 V = spm_create_vol(V);
 testCase.verifyEqual(exist(V.fname,'file'),2);
 spm_unlink(V.fname);
+end
 
 function test_spm_create_vol_nii_min(testCase)
 V = struct(...
@@ -44,6 +46,7 @@ V = struct(...
 V = spm_create_vol(V);
 testCase.verifyEqual(exist(V.fname,'file'),2);
 spm_unlink(V.fname);
+end
 
 function test_spm_create_vol_nii_multi(testCase)
 V(1:4) = deal(struct(...
@@ -57,3 +60,8 @@ for i=1:numel(V)
     testCase.verifyEqual(exist(V(i).fname,'file'),2);
     spm_unlink(V(i).fname);
 end
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_dcm_bma.m
+++ b/tests/test_spm_dcm_bma.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_bma
+classdef test_spm_dcm_bma < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_bma
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2024 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_bma(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_bma.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -42,8 +42,17 @@ expected = mean(Ep);
 % Compute probability of difference from arithmetic mean
 Pp = 1 - spm_Ncdf(expected,abs(ep_actual),vp_actual);
 testCase.assertTrue(Pp < 0.7);
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_bmr.m
+++ b/tests/test_spm_dcm_bmr.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_bmr
+classdef test_spm_dcm_bmr < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_bmr
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_bmr(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_bmr.get_data_path();
 
 % Load PEB of full DCM
 PEB = load(fullfile(data_path,'PEB_test.mat'));
@@ -40,11 +40,12 @@ assert(all(size(BMA) == [1 ns]));
 [ns,nm] = size(GCM);
 assert(all(size(RCM) == size(GCM)));
 assert(all(size(BMC) == [1 ns]));
+end
 
 % -------------------------------------------------------------------------
 function test_bmr_single_subject(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_bmr.get_data_path();
 
 % Load PEB of full DCM
 PEB = load(fullfile(data_path,'PEB_test.mat'));
@@ -74,10 +75,17 @@ assert(all(size(BMA) == [1 ns]));
 [ns,nm] = size(GCM);
 assert(all(size(RCM) == size(GCM)));
 assert(all(size(BMC) == [1 ns]));
+end
 
+end % methods (Test)
 
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_bmr_all.m
+++ b/tests/test_spm_dcm_bmr_all.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_bmr_all
+classdef test_spm_dcm_bmr_all < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_bmr_all
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_bmr_all(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_bmr_all.get_data_path();
 
 % Load PEB of full DCM
 PEB = load(fullfile(data_path,'PEB_test.mat'));
@@ -32,6 +32,7 @@ testCase.assertTrue(all(b_reduced(expected) > 1e-4));
 
 Pp = full(spm_unvec(rPEB.Pp,PEB.Ep));
 testCase.assertTrue(Pp(5,2) > 0.9);
+end
 
 % -------------------------------------------------------------------------
 % function test_divide(testCase)
@@ -44,9 +45,17 @@ testCase.assertTrue(Pp(5,2) > 0.9);
 % disp(Pk);
 % 
 % testCase.assertTrue(~all(abs(Pk) < 0.001));
+% end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_bpa.m
+++ b/tests/test_spm_dcm_bpa.m
@@ -1,11 +1,11 @@
-function tests = test_spm_dcm_bpa
+classdef test_spm_dcm_bpa < matlab.unittest.TestCase
 % Unit Tests for spm_cfg_dcm_peb (PEB batch)
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 function test_bpa(testCase)
 % A simple test in the absence of covariance
@@ -35,6 +35,7 @@ testCase.assertEqual(BPA.Cp, expected,'AbsTol',0.00001);
 
 % Posterior probability should be 0.5
 testCase.assertEqual(BPA.Pp, 0.5,'AbsTol',0.00001);
+end
 
 % -------------------------------------------------------------------------
 function test_bpa_pruned(testCase)
@@ -64,6 +65,7 @@ testCase.assertEqual(BPA.Ep, [0 0],'AbsTol',0.00001);
 testCase.assertEqual(Cp, [expected 0]','AbsTol',0.00001);
 
 testCase.assertEqual(BPA.Pp, [0.5 NaN],'AbsTol',0.00001);
+end
 
 % -------------------------------------------------------------------------
 function test_bpa_pruned2(testCase)
@@ -94,3 +96,8 @@ testCase.assertEqual(BPA.Ep, [1.5 0.1],'AbsTol',0.00001);
 testCase.assertEqual(Cp, [expected1 expected2]','AbsTol',0.00001);
 
 testCase.assertEqual(BPA.Pp, [1 NaN],'AbsTol',0.00001);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_dcm_fit.m
+++ b/tests/test_spm_dcm_fit.m
@@ -1,18 +1,22 @@
-function tests = test_spm_dcm_fit
+classdef test_spm_dcm_fit < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_fit
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm_get_defaults('dcm.verbose',false);
+    end
+end % methods (TestClassSetup)
 
-function setup(testCase)
-spm_get_defaults('dcm.verbose',false);
+
+methods (Test)
 
 function test_fmri_noparfor(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_fit.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -35,11 +39,12 @@ for i = 1:length(GCM)
     testCase.assertTrue(isfield(GCM{i},'Ep'));
     testCase.assertTrue(isfield(GCM{i},'F'));
 end
+end
 
 % -------------------------------------------------------------------------
 function test_fmri_parfor(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_fit.get_data_path();
 
 % Load DCM (one will be enough)
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -62,9 +67,17 @@ for i = 1:length(GCM)
     testCase.assertTrue(isfield(GCM{i},'Ep'));
     testCase.assertTrue(isfield(GCM{i},'F'));
 end
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_fmri_check.m
+++ b/tests/test_spm_dcm_fmri_check.m
@@ -1,11 +1,11 @@
-function tests = test_spm_dcm_fmri_check
+classdef test_spm_dcm_fmri_check < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_fmri_check
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_DCM(testCase)
@@ -13,13 +13,14 @@ function test_DCM(testCase)
 
 import matlab.unittest.constraints.*
 
-data_path = get_data_path();
+data_path = test_spm_dcm_fmri_check.get_data_path();
 dcm_file  = fullfile(data_path,'DCM_s1_m1.mat');
 
 DCM = spm_dcm_fmri_check(dcm_file, true);
 
 testCase.fatalAssertThat(DCM, HasField('diagnostics'));
 testCase.verifyThat(DCM.diagnostics, HasElementCount(3));
+end
 
 % -------------------------------------------------------------------------
 function test_GCM(testCase)
@@ -27,7 +28,7 @@ function test_GCM(testCase)
 
 import matlab.unittest.constraints.*
 
-data_path = get_data_path();
+data_path = test_spm_dcm_fmri_check.get_data_path();
 gcm_file  = fullfile(data_path,'GCM_simulated.mat');
 
 GCM = spm_dcm_fmri_check(gcm_file, true);
@@ -35,8 +36,16 @@ GCM = spm_dcm_fmri_check(gcm_file, true);
 testCase.verifyThat(GCM, IsOfClass('cell'));
 testCase.fatalAssertThat(GCM{1}, HasField('diagnostics'));
 testCase.verifyThat(GCM{1}.diagnostics, HasElementCount(3));
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region', 'models');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_fmri_csd.m
+++ b/tests/test_spm_dcm_fmri_csd.m
@@ -1,19 +1,23 @@
-function tests = test_spm_dcm_fmri_csd
+classdef test_spm_dcm_fmri_csd < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_fmri_csd
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2022 Wellcome Centre for Human Neuroimaging
 
-tests = functiontests(localfunctions);
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm_get_defaults('dcm.verbose',false);
+        spm_get_defaults('cmdline',true);
+    end
+end % methods (TestClassSetup)
 
-function setup(testCase)
-spm_get_defaults('dcm.verbose',false);
-spm_get_defaults('cmdline',true);
+
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_endogenous(testCase)
 % Tests a model with no driving inputs
-DCM = load(fullfile(get_data_path(), 'DCM_attention_CSD_endogenous_r7259.mat'));
+DCM = load(fullfile(test_spm_dcm_fmri_csd.get_data_path(), 'DCM_attention_CSD_endogenous_r7259.mat'));
 DCM = DCM.DCM;
 
 DCM = spm_dcm_fmri_csd(DCM);
@@ -21,12 +25,13 @@ DCM = spm_dcm_fmri_csd(DCM);
 testCase.assertTrue(isfield(DCM,'Ep'));
 testCase.assertTrue(isfield(DCM,'Cp'));
 testCase.assertTrue(isfield(DCM,'F'));
+end
 
 % -------------------------------------------------------------------------
 function test_driving(testCase)
 % Tests a model with no driving inputs
 
-DCM = load(fullfile(get_data_path(), 'DCM_attention_CSD_r7259.mat'));
+DCM = load(fullfile(test_spm_dcm_fmri_csd.get_data_path(), 'DCM_attention_CSD_r7259.mat'));
 DCM = DCM.DCM;
 
 DCM = spm_dcm_fmri_csd(DCM);
@@ -34,8 +39,17 @@ DCM = spm_dcm_fmri_csd(DCM);
 testCase.assertTrue(isfield(DCM,'Ep'));
 testCase.assertTrue(isfield(DCM,'Cp'));
 testCase.assertTrue(isfield(DCM,'F'));
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'test_spm_dcm_fmri_csd');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_identify.m
+++ b/tests/test_spm_dcm_identify.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_identify
+classdef test_spm_dcm_identify < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_identify
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_identify_dcm_fmri(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_identify.get_data_path();
 
 DCM = load(fullfile(data_path,'DCM_fMRI.mat'));
 DCM = DCM.DCM;
@@ -18,11 +18,12 @@ DCM = DCM.DCM;
 model = spm_dcm_identify(DCM);
 
 testCase.assertEqual(model,'fMRI');
+end
 
 % -------------------------------------------------------------------------
 function test_identify_dcm_fmri_csd(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_identify.get_data_path();
 
 DCM = load(fullfile(data_path,'DCM_fMRI_CSD.mat'));
 DCM = DCM.DCM;
@@ -30,11 +31,12 @@ DCM = DCM.DCM;
 model = spm_dcm_identify(DCM);
 
 testCase.assertEqual(model,'fMRI_CSD');
+end
 
 % -------------------------------------------------------------------------
 function test_identify_erp(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_identify.get_data_path();
 
 DCM = load(fullfile(data_path,'DCM_IMG_ERP_CMC.mat'));
 DCM = DCM.DCM;
@@ -42,11 +44,12 @@ DCM = DCM.DCM;
 model = spm_dcm_identify(DCM);
 
 testCase.assertEqual(model,'ERP');
+end
 
 % -------------------------------------------------------------------------
 function test_identify_csd(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_identify.get_data_path();
 
 DCM = load(fullfile(data_path,'DCM_LFP_CSD_CMC.mat'));
 DCM = DCM.DCM;
@@ -54,11 +57,12 @@ DCM = DCM.DCM;
 model = spm_dcm_identify(DCM);
 
 testCase.assertEqual(model,'CSD');
+end
 
 % -------------------------------------------------------------------------
 function test_identify_ind(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_identify.get_data_path();
 
 DCM = load(fullfile(data_path,'DCM_IND.mat'));
 DCM = DCM.DCM;
@@ -66,9 +70,17 @@ DCM = DCM.DCM;
 model = spm_dcm_identify(DCM);
 
 testCase.assertEqual(model,'IND');
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'test_spm_dcm_identify');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_loo.m
+++ b/tests/test_spm_dcm_loo.m
@@ -1,17 +1,17 @@
-function tests = test_spm_dcm_loo
+classdef test_spm_dcm_loo < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_peb
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_loo_group(testCase)
 % Tests LOO cross-validation in the presence of a binary group effect
 
-data_path = get_data_path();
+data_path = test_spm_dcm_loo.get_data_path();
 
 % Reduce number of subjects to increase performance
 s = [1:6 24:30];
@@ -34,12 +34,13 @@ M.X = X;
 [T,df] = spm_ancova(M.X(:,1:2),[],qE(:),[0;1]);
 p = spm_Tcdf(-T,df(2));
 testCase.assertTrue(p < 0.05);
+end
 
 % -------------------------------------------------------------------------
 function test_loo_group_null(testCase)
 % Tests LOO cross-validation in the absence of a binary group effect
 
-data_path = get_data_path();
+data_path = test_spm_dcm_loo.get_data_path();
 
 % Reduce number of subjects to increase performance
 s = [1:6 24:30];
@@ -62,12 +63,13 @@ M.X = X;
 [T,df] = spm_ancova(M.X(:,1:2),[],qE(:),[0;1]);
 p = spm_Tcdf(-T,df(2));
 testCase.assertTrue(p > 0.05);
+end
 
 % -------------------------------------------------------------------------
 function test_loo_continuous_null(testCase)
 % Tests LOO cross-validation in the absence of a continuous group effect
 
-data_path = get_data_path();
+data_path = test_spm_dcm_loo.get_data_path();
 
 % Reduce number of subjects to increase performance
 s = [1:6 24:30];
@@ -93,9 +95,17 @@ M.X = X;
 [T,df] = spm_ancova(M.X(:,1:2),[],qE(:),[0;1]);
 p = spm_Tcdf(-T,df(2));
 testCase.assertTrue(p >= 0.05);
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_peb.m
+++ b/tests/test_spm_dcm_peb.m
@@ -1,20 +1,22 @@
-function tests = test_spm_dcm_peb
+classdef test_spm_dcm_peb < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_peb
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm_get_defaults('dcm.verbose', false);
+    end
+end % methods (TestClassSetup)
 
-tests = functiontests(localfunctions);
 
-% -------------------------------------------------------------------------
-function setup(testCase)
-spm_get_defaults('dcm.verbose', false);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_peb(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb.get_data_path();
 
 % Load first level DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -47,11 +49,13 @@ testCase.assertEqual(size(PEB(1).Cp),       [np*nx np*nx]);
 
 % % Save test PEB for other tests
 % %save(fullfile(data_path,'PEB_test.mat'),'PEB');
+end
+
 % -------------------------------------------------------------------------
 function test_precision_def(testCase)
 % Tests different configurations of precision components
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb.get_data_path();
 
 % Load first level DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -93,12 +97,13 @@ M.Q = Q;
 PEB = spm_dcm_peb(GCM(:,1), M);
 testCase.assertEqual(length(PEB.Eh), 2);
 testCase.assertEqual(length(PEB.Ch), 2);
+end
 
 % -------------------------------------------------------------------------
 function test_peb_of_pebs(testCase)
 % Tests hierarchical models with PEB as the input to other PEBs
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb.get_data_path();
 
 % Load first level DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -125,11 +130,12 @@ M = struct();
 M.X = [1 1; 1 -1];
 M.Q = 'none';
 PEB  = spm_dcm_peb({PEB1;PEB2},M);
+end
 
 % -------------------------------------------------------------------------
 function test_peb_with_rank_deficient_priors(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb.get_data_path();
 
 % Load first level DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -150,9 +156,17 @@ PEB = spm_dcm_peb(GCM(:,1), X, fields);
 
 % Check output sizes
 testCase.assertTrue(all(PEB.Ep(5,:) == 0));
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_peb_bmc.m
+++ b/tests/test_spm_dcm_peb_bmc.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_peb_bmc
+classdef test_spm_dcm_peb_bmc < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_peb_bmc
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_model_search(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_bmc.get_data_path();
 
 PEB = load(fullfile(data_path,'PEB_test.mat'));
 PEB = PEB.PEB;
@@ -35,11 +35,12 @@ Pp_others(connection,:) = [];
 testCase.assertTrue(all(Pp_others(connection,effect) < 0.95));
 
 close all;
+end
 
 % -------------------------------------------------------------------------
 function test_specific_model_comparison(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_bmc.get_data_path();
 
 % Get PEB full model
 PEB = load(fullfile(data_path,'PEB_test.mat'));
@@ -69,12 +70,13 @@ testCase.assertTrue(BMA.Px(1) > 0.95);
 testCase.assertTrue(BMA.Px(2) < 0.95);
 
 close all;
+end
 
 % -------------------------------------------------------------------------
 function test_self_connection_onoff(testCase)
 % Implemented to confirm that self-connections on A in DCM for fMRI models
 % can be varied across models.
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_bmc.get_data_path();
 
 % Get PEB full model
 PEB = load(fullfile(data_path,'PEB_test.mat'));
@@ -98,12 +100,13 @@ GCM_templates{2}.b(2,1,2) = 0;
 testCase.assertTrue(length(BMA.Kname) == 2);
 
 close all;
+end
 
 % -------------------------------------------------------------------------
 function test_bmc_peb_of_pebs(testCase)
 % Tests model comparison with hierarchical models
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_bmc.get_data_path();
 
 % Load first level DCMs
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -157,9 +160,17 @@ GCM_templates{2}.b(2,1,2) = 0;
 assert(length(BMA.Kname) == 1);
 
 close all
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_peb_bmc_fam.m
+++ b/tests/test_spm_dcm_peb_bmc_fam.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_peb_bmc_fam
+classdef test_spm_dcm_peb_bmc_fam < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_peb_bmc_fam
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_peb_bmc_fam(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_bmc_fam.get_data_path();
 
 % Load
 GCM = load(fullfile(data_path,'models','GCM_simulated.mat'));
@@ -61,9 +61,17 @@ for f = 1:2
 end
 testCase.assertTrue(...
     all(family_total_prior(:) - family_total_prior(1) < 1e-10));
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_peb_review.m
+++ b/tests/test_spm_dcm_peb_review.m
@@ -1,4 +1,4 @@
-function tests = test_spm_dcm_peb_review
+classdef test_spm_dcm_peb_review < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_peb_review. Simply ensures that the GUI
 % doesn't crash with different inputs.
 %__________________________________________________________________________
@@ -6,22 +6,24 @@ function tests = test_spm_dcm_peb_review
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_with_peb(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_review.get_data_path();
 
 PEB = fullfile(data_path,'PEB_test.mat');
 DCM = fullfile(data_path,'models','DCM_s1_m1.mat');
 
 spm_dcm_peb_review(PEB,DCM);
 close all;
+end
+
 % -------------------------------------------------------------------------
 function test_with_unestimated_dcm(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_review.get_data_path();
 
 PEB = fullfile(data_path,'PEB_test.mat');
 DCM = fullfile(data_path,'models','DCM_s1_m1.mat');
@@ -42,29 +44,41 @@ DCM2.options=DCM.options;
 
 spm_dcm_peb_review(PEB,DCM2);
 close all;
+end
 
 % -------------------------------------------------------------------------
 function test_with_bma_search(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_review.get_data_path();
 
 BMA = fullfile(data_path,'BMA_search.mat');
 DCM = fullfile(data_path,'models','DCM_s1_m1.mat');
 
 spm_dcm_peb_review(BMA,DCM);
 close all;
+end
+
 % -------------------------------------------------------------------------
 function test_with_bma_specific_models(testCase)
 
-data_path = get_data_path();
+data_path = test_spm_dcm_peb_review.get_data_path();
 
 BMA = fullfile(data_path,'BMA_specific_models.mat');
 DCM = fullfile(data_path,'models','DCM_s1_m1.mat');
 
 spm_dcm_peb_review(BMA,DCM);
 close all;
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region');
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_peb_to_gcm.m
+++ b/tests/test_spm_dcm_peb_to_gcm.m
@@ -1,16 +1,10 @@
-function tests = test_spm_dcm_peb_to_gcm
+classdef test_spm_dcm_peb_to_gcm < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_peb_to_gcm
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
-
-tests = functiontests(localfunctions);
-
-%--------------------------------------------------------------------------
-function data_path = get_data_path()
-data_path = fullfile( spm('Dir'), 'tests', ...
-    'data', 'test_spm_dcm_peb_to_gcm');
+methods (Test)
 
 %--------------------------------------------------------------------------
 function test_2groups(testCase)
@@ -26,7 +20,7 @@ beta  = 16;         % Within:between variance ratio for simulated parameters
 rng(1);
 
 % Load template DCM
-DCM_template = fullfile(get_data_path(), 'DCM_attention.mat');
+DCM_template = fullfile(test_spm_dcm_peb_to_gcm.get_data_path(), 'DCM_attention.mat');
 DCM_template = load(DCM_template);
 DCM_template = DCM_template.DCM;
 
@@ -40,7 +34,7 @@ X             = ones(n,2);
 X(group{2},2) = -1;
 
 % Create dummy PEB
-PEB = create_peb(DCM_template, X, b_Hz, param, beta);
+PEB = test_spm_dcm_peb_to_gcm.create_peb(DCM_template, X, b_Hz, param, beta);
 
 % Create GCM array
 options = struct('nsubjects',n);
@@ -58,7 +52,7 @@ Eps = Eps(PEB.Pind,:);
 
 % Check subject' parameters are similar to PEB.Ep(:,1)
 testCase.assertGreaterThanOrEqual(...
-    one_sample_tt(mean(Eps,2)-PEB.Ep(:,1)),...
+    test_spm_dcm_peb_to_gcm.one_sample_tt(mean(Eps,2)-PEB.Ep(:,1)),...
     0.05);
 
 % Check group difference in B-parameter is similar to PEB.Ep(idx,2)
@@ -76,14 +70,24 @@ for g = 1:length(group)
     
     % Check group mean is similar to PEB parameter
     testCase.assertGreaterThanOrEqual(...
-        one_sample_tt(Eps(idx,:), expected(g)),...
+        test_spm_dcm_peb_to_gcm.one_sample_tt(Eps(idx,:), expected(g)),...
         0.05);
     
     % Check that between-subjects variance of parameters is as expected
     testCase.assertGreaterThanOrEqual(...
-        one_sample_tt(diag(PEB.Ce) - var(Eps(PEB.Pind,:),[],2)),...
+        test_spm_dcm_peb_to_gcm.one_sample_tt(diag(PEB.Ce) - var(Eps(PEB.Pind,:),[],2)),...
         0.05);    
     
+end
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
+%--------------------------------------------------------------------------
+function data_path = get_data_path()
+data_path = fullfile( spm('Dir'), 'tests', ...
+    'data', 'test_spm_dcm_peb_to_gcm');
 end
 
 %--------------------------------------------------------------------------
@@ -125,6 +129,7 @@ PEB.Ep   = [gP(Pind) att(Pind)];
 PEB.beta = beta;
 PEB.Pind = Pind;
 PEB.M.X  = X;
+end
 
 % -------------------------------------------------------------------------
 function p = one_sample_tt(data,mu)
@@ -133,3 +138,7 @@ function p = one_sample_tt(data,mu)
 if nargin < 2, mu = 0; end
 t = (mean(data)-mu) / (std(data) / sqrt(length(data)));
 p = spm_Tcdf(-t,length(data)-1) * 2;
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dcm_post_hoc.m
+++ b/tests/test_spm_dcm_post_hoc.m
@@ -1,42 +1,38 @@
-function tests = test_spm_dcm_post_hoc
+classdef test_spm_dcm_post_hoc < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_post_hoc
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        data_path = test_spm_dcm_post_hoc.get_data_path();
 
+        % Expected outputs
+        artefacts = {fullfile(data_path,'DCM_BPA.mat');
+                    fullfile(data_path,'DCM_opt_fwd_bwd_simulated.mat')};
+            
+        % Delete if exist
+        for i = 1:length(artefacts)
+            spm_unlink(artefacts{i});   
+        end
 
-%--------------------------------------------------------------------------
-function data_path = get_data_path()
-data_path = fullfile( spm('Dir'), 'tests', ...
-    'data', 'test_spm_dcm_post_hoc');
+        % Initialize SPM
+        spm('defaults','fmri');
+        spm_get_defaults('cmdline',true);
 
+    end
+end % methods (TestClassSetup)
 
-%--------------------------------------------------------------------------
-function setup(testCase)
-data_path = get_data_path();
-
-% Expected outputs
-artefacts = {fullfile(data_path,'DCM_BPA.mat');
-             fullfile(data_path,'DCM_opt_fwd_bwd_simulated.mat')};
-    
-% Delete if exist
-for i = 1:length(artefacts)
-    spm_unlink(artefacts{i});   
-end
-
-% Initialize SPM
-spm('defaults','fmri');
-spm_get_defaults('cmdline',true);
+methods (Test)
 
 
 %--------------------------------------------------------------------------
 function test_on_simulated_attention_data(testCase)
 import matlab.unittest.constraints.*
  
-data_path = get_data_path();
+data_path = test_spm_dcm_post_hoc.get_data_path();
 
 % Load model matching the generative model
 DCM_fwd = load(fullfile(data_path, 'DCM_fwd_simulated.mat'));
@@ -74,3 +70,16 @@ testCase.assertTrue(all(pC_fwd == pC_opt));
 % 
 % subplot(2,2,4); spm_plot_ci(DCM_opt.Ep,DCM_opt.Cp);
 % title('Optimal model for subject'); xlabel('Parameter');
+end
+
+end % methods (Test)
+
+methods (Static, Access = private)
+    %--------------------------------------------------------------------------
+    function data_path = get_data_path()
+        data_path = fullfile( spm('Dir'), 'tests', ...
+            'data', 'test_spm_dcm_post_hoc');
+    end
+end
+
+end % classdef

--- a/tests/test_spm_dcm_simulate.m
+++ b/tests/test_spm_dcm_simulate.m
@@ -1,16 +1,16 @@
-function tests = test_spm_dcm_simulate
+classdef test_spm_dcm_simulate < matlab.unittest.TestCase
 % Unit Tests for test_spm_dcm_simulate
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_simulate_snr_var_fmri(testCase)
 % Test simulation based on SNR variance
-data_path = get_data_path();
+data_path = test_spm_dcm_simulate.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'GCM_simulated.mat'));
@@ -44,14 +44,15 @@ nr = size(actual_snr,2); % Number of regions
 % the expected value (one-sample ttest)
 for n = 1:nr    
     data = actual_snr(:,n);
-    p    = one_sample_tt(data,SNR);
+    p    = test_spm_dcm_simulate.one_sample_tt(data,SNR);
     testCase.assertTrue(p >= 0.05);
+end
 end
 
 % -------------------------------------------------------------------------
 function test_simulate_snr_std_fmri(testCase)
 % Test simulation based on SNR standard deviatoin
-data_path = get_data_path();
+data_path = test_spm_dcm_simulate.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'GCM_simulated.mat'));
@@ -84,14 +85,15 @@ nr = size(actual_snr,2); % Number of regions
 % the expected value (one-sample ttest)
 for n = 1:nr    
     data = actual_snr(:,n);
-    p    = one_sample_tt(data,SNR);
+    p    = test_spm_dcm_simulate.one_sample_tt(data,SNR);
     testCase.assertTrue(p >= 0.05);
+end
 end
 
 % -------------------------------------------------------------------------
 function test_simulate_snr_var(testCase)
 % Test simulation based on fixed noise variance
-data_path = get_data_path();
+data_path = test_spm_dcm_simulate.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'GCM_simulated.mat'));
@@ -125,14 +127,15 @@ nr = size(actual_var,2); % Number of regions
 % the expected value (one-sample ttest)
 for n = 1:nr    
     data = actual_var(:,n);
-    p    = one_sample_tt(data,noise_var);
+    p    = test_spm_dcm_simulate.one_sample_tt(data,noise_var);
     testCase.assertTrue(p >= 0.05);
+end
 end
 
 % -------------------------------------------------------------------------
 function test_simulate_Ce(testCase)
 % Test simulation based on fixed noise variance
-data_path = get_data_path();
+data_path = test_spm_dcm_simulate.get_data_path();
 
 % Load DCMs
 GCM = load(fullfile(data_path,'GCM_simulated.mat'));
@@ -171,18 +174,29 @@ nr = size(actual_var,2); % Number of regions
 % the expected value (one-sample ttest)
 for n = 1:nr    
     data = actual_var(:,n);
-    p    = one_sample_tt(data,noise_var(n));
+    p    = test_spm_dcm_simulate.one_sample_tt(data,noise_var(n));
     testCase.assertTrue(p >= 0.05);
 end
+end
 
+end % methods (Test)
+
+% Helper methods
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function p = one_sample_tt(data,mu)
 % One sample t-test
 t = (mean(data)-mu) / (std(data) / sqrt(length(data)));
 p = spm_Tcdf(-t,length(data)-1) * 2;
+end
 
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'fMRI', 'simulated_2region', 'models');
+end
+
+end % Helper methods
+
+end % classdef

--- a/tests/test_spm_dcm_specify.m
+++ b/tests/test_spm_dcm_specify.m
@@ -1,17 +1,17 @@
-function tests = test_spm_dcm_specify
+classdef test_spm_dcm_specify < matlab.unittest.TestCase
 % Unit Tests for spm_dcm_specify_ui
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_inputs_by_name(testCase)
 
 % Identify SPM
-glm_dir = get_data_path();
+glm_dir = test_spm_dcm_specify.get_data_path();
 SPM = load(fullfile(glm_dir,'SPM.mat'));
 SPM = SPM.SPM;
 
@@ -33,7 +33,7 @@ cond(5).name    = 'Lag quadratic';
 cond(5).spmname = {'N2xLag^2','F2xLag^2'};
 
 % Specify DCM
-DCM = run_specify(cond,SPM,testCase);
+DCM = test_spm_dcm_specify.run_specify(cond,SPM,testCase);
 
 % Combine conditions manually and check they match those in the DCM
 k = 33:(size(SPM.Sess.U(1).u,1));
@@ -53,13 +53,13 @@ testCase.assertEqual(DCM.U.u(:,4), ...
 
 testCase.assertEqual(DCM.U.u(:,5), ...
     double(SPM.Sess.U(2).u(k,3) | SPM.Sess.U(4).u(k,3)));
-
+end
 
 % -------------------------------------------------------------------------
 function test_inputs_by_ID(testCase)
 
 % Identify SPM
-glm_dir = get_data_path();
+glm_dir = test_spm_dcm_specify.get_data_path();
 SPM = load(fullfile(glm_dir,'SPM.mat'));
 SPM = SPM.SPM;
 
@@ -67,7 +67,7 @@ u = [1 0 0
      0 1 0
      1 0 0
      0 0 1];
-DCM = run_specify(u,SPM,testCase);
+DCM = test_spm_dcm_specify.run_specify(u,SPM,testCase);
 
 % Get conditions manually and check they match those in the DCM
 k = 33:(size(SPM.Sess.U(1).u,1));
@@ -75,13 +75,19 @@ testCase.assertEqual(DCM.U.u(:,1), SPM.Sess.U(1).u(k,1));
 testCase.assertEqual(DCM.U.u(:,2), SPM.Sess.U(2).u(k,2));
 testCase.assertEqual(DCM.U.u(:,3), SPM.Sess.U(3).u(k,1));
 testCase.assertEqual(DCM.U.u(:,4), SPM.Sess.U(4).u(k,3));
+end
 
+end % methods (Test)
+
+
+% Helper methods
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function DCM = run_specify(spec,SPM,testCase)
 % input 'spec' determines how the DCM input is specified. Can be a 
 % structure or matrix of condition indices.
 
-glm_dir = get_data_path();
+glm_dir = test_spm_dcm_specify.get_data_path();
 xY = {fullfile(glm_dir,'VOI_lFus_1.mat');
       fullfile(glm_dir,'VOI_rFus_1.mat')};
 
@@ -144,9 +150,15 @@ testCase.assertEqual(DCM.a,s.a);
 testCase.assertEqual(DCM.b,s.b);
 testCase.assertEqual(DCM.c,s.c);
 testCase.assertEqual(DCM.d,s.d);
+end
 
 % -------------------------------------------------------------------------
 function data_path = get_data_path()
 
 data_path = fullfile( spm('Dir'), 'tests', ...
     'data', 'test_spm_dcm_specify');
+end
+
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_dctmtx.m
+++ b/tests/test_spm_dctmtx.m
@@ -1,11 +1,12 @@
-function tests = test_spm_dctmtx
+classdef test_spm_dctmtx < matlab.unittest.TestCase
 % Unit Tests for spm_dctmtx
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_dctmtx_1(testCase)
@@ -19,7 +20,7 @@ exp = eye(N);
 act = C'*C;
 tol = 100*eps;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_dctmtx_2(testCase)
 N = 16;
@@ -34,7 +35,7 @@ exp = eye(K);
 act = C'*C;
 tol = 100*eps;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_dctmtx_3(testCase)
 N = 16;
@@ -56,7 +57,7 @@ C = spm_dctmtx(N,K,'diff2');
 exp = [N K];
 act = size(C);
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_dctmtx_4(testCase)
 N = 16;
@@ -76,3 +77,8 @@ act = size(C);
 testCase.verifyEqual(act, exp);
 
 testCase.verifyError(@()spm_dctmtx(N,K,n,'XXX'),?MException);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_average.m
+++ b/tests/test_spm_eeg_average.m
@@ -1,16 +1,19 @@
-function tests = test_spm_eeg_average
+classdef test_spm_eeg_average < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_average
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('defaults', 'eeg');
+    end
+end % methods (TestClassSetup)
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_eeg_average_1(testCase)
-
-spm('defaults','eeg');
 
 fname = fullfile(spm('Dir'),'tests','data','OPM','test_opm.mat');
 D     = spm_eeg_load(fname);
@@ -41,3 +44,8 @@ exp = 6;
 
 
 testCase.verifyTrue(abs((act-exp)/exp)< 1e-6);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_bc.m
+++ b/tests/test_spm_eeg_bc.m
@@ -1,16 +1,19 @@
-function tests = test_spm_eeg_bc
+classdef test_spm_eeg_bc < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_bc
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('defaults', 'eeg');
+    end
+end % methods (TestClassSetup)
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_eeg_bc_1(testCase)
-
-spm('defaults','eeg');
 
 fname = fullfile(spm('Dir'),'tests','data','OPM','test_opm.mat');
 D     = spm_eeg_load(fname);
@@ -31,3 +34,8 @@ actCorrected = mean(mean(bD(:,501:1000,:)))==10;
 
 
 testCase.verifyTrue(baseCorrected & actCorrected);
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_crop.m
+++ b/tests/test_spm_eeg_crop.m
@@ -1,16 +1,19 @@
-function tests = test_spm_eeg_crop
+classdef test_spm_eeg_crop < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_crop
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
+methods (TestClassSetup)
+    function setupSPM(testCase)
+        spm('defaults', 'eeg');
+    end
+end % methods (TestClassSetup)
 
-tests = functiontests(localfunctions);
+methods (Test)
 
 
 function test_spm_eeg_crop_1(testCase)
-
-spm('defaults','eeg');
 
 fname = fullfile(spm('Dir'),'tests','data','OPM','test_opm.mat');
 D     = spm_eeg_load(fname);
@@ -29,3 +32,8 @@ siD = size(cD);
 delete(cD);
 
 testCase.verifyTrue(all(siD==[30, 500, 1]));
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_ffilter.m
+++ b/tests/test_spm_eeg_ffilter.m
@@ -1,11 +1,12 @@
-function tests = test_spm_eeg_ffilter
+classdef test_spm_eeg_ffilter < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_ffilter
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_eeg_ffilter_1(testCase)
@@ -36,3 +37,7 @@ res = mean(std(fD(:,900:1000,1),[],2));
 dB = 20*log10(mean(Y./res));
 
 testCase.verifyTrue(dB>100);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_filter.m
+++ b/tests/test_spm_eeg_filter.m
@@ -1,11 +1,12 @@
-function tests = test_spm_eeg_filter
+classdef test_spm_eeg_filter < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_filter
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_eeg_filter_1(testCase)
@@ -36,3 +37,7 @@ res = mean(std(fD(:,900:1000,1),[],2));
 dB = 20*log10(mean(Y./res));
 
 testCase.verifyTrue(dB>100);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_grandmean.m
+++ b/tests/test_spm_eeg_grandmean.m
@@ -1,11 +1,12 @@
-function tests = test_spm_eeg_grandmean
+classdef test_spm_eeg_grandmean < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_merge
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_eeg_grandmean_1(testCase)
@@ -37,3 +38,7 @@ D.save()
 err = abs(mu-4.5);
 
 testCase.verifyTrue(err < 1e-7);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_load.m
+++ b/tests/test_spm_eeg_load.m
@@ -1,11 +1,12 @@
-function tests = test_spm_eeg_load
+classdef test_spm_eeg_load < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_load
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_eeg_load_1(testCase)
@@ -26,3 +27,7 @@ testCase.verifyTrue(isequal(exp, act));
 exp = [110,1000,1];
 act = size(D);
 testCase.verifyTrue(isequal(exp, act));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_eeg_merge.m
+++ b/tests/test_spm_eeg_merge.m
@@ -1,11 +1,12 @@
-function tests = test_spm_eeg_merge
+classdef test_spm_eeg_merge < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_merge
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_eeg_merge_1(testCase)
@@ -32,3 +33,7 @@ Dout.delete();
 D2.delete();
 
 testCase.verifyTrue(all(siD == [110,1000,2]));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_fileparts.m
+++ b/tests/test_spm_fileparts.m
@@ -1,11 +1,12 @@
-function tests = test_spm_fileparts
+classdef test_spm_fileparts < matlab.unittest.TestCase
 % Unit Tests for spm_fileparts
 %__________________________________________________________________________
 
 % Copyright (C) 2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_fileparts_char(testCase)
@@ -46,3 +47,7 @@ testCase.verifyEqual(pth, spm('Dir'));
 testCase.verifyEqual(nam, 'image');
 testCase.verifyEqual(ext, '.nii');
 testCase.verifyEqual(num, ',2,5');
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_filter.m
+++ b/tests/test_spm_filter.m
@@ -1,11 +1,12 @@
-function tests = test_spm_filter
+classdef test_spm_filter < matlab.unittest.TestCase
 % Unit Tests for spm_filter
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_filter_1(testCase)
@@ -16,7 +17,7 @@ K = spm_filter(K);
 testCase.verifyThat(K, HasField('X0'));
 testCase.verifyThat(K, HasLength(1));
 testCase.verifyThat(K.X0, HasSize([64 2]));
-
+end
 
 function test_spm_filter_2(testCase)
 K  = struct('RT',2.4,'row',1:64,'HParam',128);
@@ -28,7 +29,7 @@ exp = Yf;
 act = spm_filter(eye(64)- K.X0*K.X0',Y);
 tol = 1e-10;
 testCase.verifyEqual(exp, act,'AbsTol',tol);
-
+end
 
 function test_spm_filter_3(testCase)
 import matlab.unittest.constraints.*
@@ -38,3 +39,7 @@ K  = spm_filter(K);
 Yf = spm_filter(K,Y);
 
 testCase.verifyThat(Yf, HasSize(size(Y)));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_gamrnd.m
+++ b/tests/test_spm_gamrnd.m
@@ -1,11 +1,12 @@
-function tests = test_spm_gamrnd
+classdef test_spm_gamrnd < matlab.unittest.TestCase
 % Unit Tests for spm_gamrnd
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_gamrnd_1(testCase)
@@ -27,3 +28,7 @@ testCase.verifyThat(g, IsGreaterThan(0));
 g = spm_gamrnd(2,5,[3,5]);
 %testCase.verifyThat(g, HasSize([3 5]));
 testCase.verifyThat(g, IsGreaterThan(0));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_get_data.m
+++ b/tests/test_spm_get_data.m
@@ -1,11 +1,12 @@
-function tests = test_spm_get_data
+classdef test_spm_get_data < matlab.unittest.TestCase
 % Unit Tests for spm_get_data
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_get_data_1(testCase)
@@ -23,8 +24,12 @@ act = spm_get_data(char(...
     fullfile(spm('Dir'),'canonical','avg152T2.nii')),[1 1 1;2 2 2]');
 testCase.verifyTrue(isnumeric(act));
 testCase.verifyTrue(isequal(size(act),[3 2]));
-
+end
 
 function test_spm_get_data_error(testCase)
 err = @() evalc('spm_get_data(struct(''fname'',tempname),[1 1 1]'')');
 testCase.verifyError(err, ?MException);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_get_lm.m
+++ b/tests/test_spm_get_lm.m
@@ -1,11 +1,12 @@
-function tests = test_spm_get_lm
+classdef test_spm_get_lm < matlab.unittest.TestCase
 % Unit Tests for spm_get_lm
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_get_lm_2D(testCase)
@@ -17,7 +18,7 @@ vol(3,3) = max(subvol(:)) + 0.1;
 gm      = sub2ind(size(vol),3,3);
 idx     = spm_get_lm(vol,[X(:)';Y(:)']);
 testCase.verifyTrue(any(idx == gm));
-
+end
 
 function test_spm_get_lm_3D(testCase)
 dim     = [5 5 5];
@@ -28,3 +29,7 @@ vol(3,3,3) = max(subvol(:)) + 0.1;
 gm      = sub2ind(size(vol),3,3,3);
 idx     = spm_get_lm(vol,[X(:)';Y(:)';Z(:)']);
 testCase.verifyTrue(any(idx == gm));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_invNcdf.m
+++ b/tests/test_spm_invNcdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_invNcdf
+classdef test_spm_invNcdf < matlab.unittest.TestCase
 % Unit Tests for spm_invNcdf
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_invNcdf_1(testCase)
@@ -13,12 +14,14 @@ exp = 1.644853626951473; % norminv(1 - 0.05)
 act = spm_invNcdf(1 - 0.05);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_invNcdf_2(testCase)
 exp = -1.644853626951473; % norminv(0.05)
 act = spm_invNcdf(0.05);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_invNcdf_3(testCase)
 exp = [NaN -Inf 0 Inf NaN];
@@ -27,21 +30,28 @@ act = spm_invNcdf([-1 0 0.5 1 2]);
 warning(ws);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_invNcdf_4(testCase)
 exp = 4.848970052893895; % norminv(1 - 0.05,2,sqrt(3))
 act = spm_invNcdf(1 - 0.05, 2, 3);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_invNcdf_5(testCase)
 exp = -8.222082216130437; % norminv(10^-16)
 act = spm_invNcdf(10^-16);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_invNcdf_6(testCase)
 exp = -8.493793224109599; % norminv(10^-17)
 act = spm_invNcdf(10^-17);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_jsonread.m
+++ b/tests/test_spm_jsonread.m
@@ -1,11 +1,12 @@
-function tests = test_spm_jsonread
+classdef test_spm_jsonread < matlab.unittest.TestCase
 % Unit Tests for spm_jsonread
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_jsonread_from_string_1(testCase)
@@ -14,6 +15,7 @@ json = '["one", "two", "three"]';
 exp = {'one';'two';'three'};
 act = spm_jsonread(json);
 testCase.verifyTrue(isequal(exp, act));
+end
 
 function test_jsonread_from_string_2(testCase)
 json = '{"Width":800,"Height":600,"Title":"View from the 15th Floor","Animated":false,"IDs":[116,943,234,38793]}';
@@ -21,6 +23,7 @@ json = '{"Width":800,"Height":600,"Title":"View from the 15th Floor","Animated":
 exp = struct('Width',800,'Height',600,'Title','View from the 15th Floor','Animated',false,'IDs',[116;943;234;38793]);
 act = spm_jsonread(json);
 testCase.verifyTrue(isequal(exp, act));
+end
 
 function test_jsonread_all_types(testCase)
 
@@ -178,3 +181,7 @@ json = '[[[1,2],[3,4]],[[5,6],[7,8]]]';
 exp  = cat(3,[1,3;5,7],[2,4;6,8]);
 act  = spm_jsonread(json);
 testCase.verifyTrue(isequal(exp, act));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_jsonwrite.m
+++ b/tests/test_spm_jsonwrite.m
@@ -1,11 +1,12 @@
-function tests = test_spm_jsonwrite
+classdef test_spm_jsonwrite < matlab.unittest.TestCase
 % Unit Tests for spm_jsonwrite
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_jsonwrite_array(testCase)
@@ -16,11 +17,13 @@ testCase.verifyTrue(isequal(exp, act));
 exp = 2;
 act = nnz(spm_jsonwrite(1:3) == ',');
 testCase.verifyTrue(isequal(exp, act));
+end
 
 function test_jsonwrite_object(testCase)
 exp = struct('Width',800,'Height',600,'Title','View from the 15th Floor','Animated',false,'IDs',[116;943;234;38793]);
 act = spm_jsonread(spm_jsonwrite(exp));
 testCase.verifyTrue(isequal(exp, act));
+end
 
 function test_jsonwrite_all_types(testCase)
 exp = [];
@@ -50,6 +53,7 @@ testCase.verifyTrue(isequaln(act, exp));
 %exp = {'one  ';'two  ';'three'};
 %act = spm_jsonread(spm_jsonwrite(str));
 %testCase.verifyTrue(isequal(exp, act));
+end
 
 function test_options(testCase)
 exp = struct('Width',800,'Height',NaN,'Title','View','Bool',true);
@@ -67,3 +71,7 @@ spm_jsonwrite(exp,struct('indent','\t','convertInfAndNaN',false));
 spm_jsonwrite(exp,'prettyPrint',true,'replacementStyle','hex','convertInfAndNaN',false);
 spm_jsonwrite(exp,struct('prettyPrint',true));
 spm_jsonwrite(exp,struct('prettyPrint',true,'convertInfAndNaN',false));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mar.m
+++ b/tests/test_spm_mar.m
@@ -1,10 +1,11 @@
-function tests = test_spm_mar
+classdef test_spm_mar < matlab.unittest.TestCase
 % Unit Tests for spm_mar
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_estimation(testCase)
@@ -62,3 +63,7 @@ testCase.verifyEqual(A2(:),-mar{p}.lag(2).a(:),'AbsTol',0.2);
 
 % Test noise covariance
 testCase.verifyEqual(C(:),mar{p}.noise_cov(:),'AbsTol',0.2);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_adjacency.m
+++ b/tests/test_spm_mesh_adjacency.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_adjacency
+classdef test_spm_mesh_adjacency < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_adjacency
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_adjacency_tetrahedron(testCase)
@@ -17,7 +18,7 @@ testCase.verifyEqual(act, exp);
 
 act = spm_mesh_adjacency(M.faces);
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_mesh_adjacency_octahedron(testCase)
 M = spm_mesh_polyhedron('octahedron');
@@ -34,7 +35,7 @@ testCase.verifyEqual(act, exp);
 
 act = spm_mesh_adjacency(M.faces);
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_mesh_adjacency_icosahedron(testCase)
 M = spm_mesh_polyhedron('icosahedron');
@@ -57,3 +58,7 @@ testCase.verifyEqual(act, exp);
 
 act = spm_mesh_adjacency(M.faces);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_area.m
+++ b/tests/test_spm_mesh_area.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_area
+classdef test_spm_mesh_area < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_area
 %__________________________________________________________________________
 
 % Copyright (C) 2021-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_area_polyhedron(testCase)
@@ -30,7 +31,7 @@ a = 2;
 exp = sqrt(3)*a^2;
 act = spm_mesh_area(M);
 testCase.verifyEqual(act, exp, 'AbsTol',1e-6);
-
+end
 
 function test_spm_mesh_area_sphere(testCase)
 
@@ -47,3 +48,7 @@ testCase.verifyEqual(act, exp, 'AbsTol',1e-2);
 exp = 4*pi;
 act = sum(spm_mesh_area(M,'vertex'));
 testCase.verifyEqual(act, exp, 'AbsTol',1e-2);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_borders.m
+++ b/tests/test_spm_mesh_borders.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_borders
+classdef test_spm_mesh_borders < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_borders
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_borders_sphere(testCase)
@@ -21,6 +22,7 @@ M.faces(end,:) = [];
 [act,C] = spm_mesh_borders(M);
 testCase.verifyEqual(act, exp);
 testCase.verifyEqual(numel(C), 1);
+end
 
 function test_spm_mesh_borders_sphere_4(testCase)
 M = spm_mesh_sphere(4);
@@ -35,6 +37,7 @@ exp = 94;
 act = numel(B);
 testCase.verifyEqual(act, exp);
 testCase.verifyEqual(numel(C), 1);
+end
 
 function test_spm_mesh_borders_sphere_5(testCase)
 M = spm_mesh_sphere(5);
@@ -46,6 +49,7 @@ exp = 190;
 act = numel(B);
 testCase.verifyEqual(act, exp);
 testCase.verifyEqual(numel(C), 1);
+end
 
 function test_spm_mesh_borders_two_spheres(testCase)
 M1 = spm_mesh_sphere(4);
@@ -62,3 +66,7 @@ act = numel(B);
 testCase.verifyEqual(act, exp);
 testCase.verifyEqual(numel(C), 2);
 testCase.verifyEqual(sort(cellfun(@numel,C)), [94 190]);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_contour.m
+++ b/tests/test_spm_mesh_contour.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_contour
+classdef test_spm_mesh_contour < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_contour
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_contour_(testCase)
@@ -19,3 +20,7 @@ testCase.verifyGreaterThanOrEqual(act, exp);
 
 % all surfaces are closed
 testCase.verifyFalse(any([S.isopen]));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_dist.m
+++ b/tests/test_spm_mesh_dist.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_dist
+classdef test_spm_mesh_dist < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_dist
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_dist_(testCase)
@@ -94,7 +95,7 @@ for x=-2:0.13:2
     for y=-2:0.13:2
         for z=-2:0.13:2
             act(i) = spm_mesh_dist(M,[x y z]);
-            exp(i) = dist_cube([x y z]);
+            exp(i) = test_spm_mesh_dist.dist_cube([x y z]);
             i = i + 1;
         end
     end
@@ -106,11 +107,14 @@ XYZ = [X(:) Y(:) Z(:)];
 act = spm_mesh_dist(M,XYZ);
 exp = zeros(size(act));
 for i=1:size(XYZ,1)
-    exp(i) = dist_cube(XYZ(i,:));
+    exp(i) = test_spm_mesh_dist.dist_cube(XYZ(i,:));
 end
 testCase.verifyEqual(act, exp, 'AbsTol',1e-10);
+end
 
+end % methods (Test)
 
+methods (Static, Access = private)
 function d = dist_cube(XYZ)
 dx = max([[-1 -1 -1] - XYZ; XYZ - [1 1 1]], [], 1);
 if max(dx) < 0
@@ -118,3 +122,8 @@ if max(dx) < 0
 else
     d = sqrt(sum(dx(dx>0).^2));
 end
+
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_mesh_edges.m
+++ b/tests/test_spm_mesh_edges.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_edges
+classdef test_spm_mesh_edges < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_edges
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_edges_struct(testCase)
@@ -30,6 +31,7 @@ testCase.verifyEqual(act, exp);
 exp = true;
 act = all(L < 2);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_edges_faces(testCase)
 M = spm_mesh_cube;
@@ -39,3 +41,7 @@ E = spm_mesh_edges(M.faces);
 exp = [18, 2];
 act = size(E);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_euler.m
+++ b/tests/test_spm_mesh_euler.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_euler
+classdef test_spm_mesh_euler < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_euler
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_euler_polyhedron(testCase)
@@ -23,6 +24,7 @@ M = spm_mesh_polyhedron('icosahedron');
 exp = 2;
 act = spm_mesh_euler(M);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_euler_sphere(testCase)
 
@@ -38,3 +40,7 @@ M = spm_mesh_join([M1,M2]);
 exp = 4;
 act = spm_mesh_euler(M);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_geodesic.m
+++ b/tests/test_spm_mesh_geodesic.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_geodesic
+classdef test_spm_mesh_geodesic < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_geodesic
 %__________________________________________________________________________
 
 % Copyright (C) 2020-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_geodesic_(testCase)
@@ -26,3 +27,7 @@ testCase.verifyTrue(iscell(P));
 [D,L] = spm_mesh_geodesic(M,1:100:size(M.vertices,1));
 testCase.verifyTrue(max(D) < pi);
 testCase.verifyTrue(numel(unique(L)) > 1);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_get_lm.m
+++ b/tests/test_spm_mesh_get_lm.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_get_lm
+classdef test_spm_mesh_get_lm < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_get_lm
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_get_lm_octahedron(testCase)
@@ -15,6 +16,7 @@ T = [2 1 NaN 1 1 2]';
 exp = [1 6];
 act = spm_mesh_get_lm(M,T);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_get_lm_one(testCase)
 M = spm_mesh_polyhedron('octahedron');
@@ -24,6 +26,7 @@ T(3) = 1;
 exp = 3;
 act = spm_mesh_get_lm(M,T);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_get_lm_NaN(testCase)
 M = spm_mesh_polyhedron('octahedron');
@@ -32,6 +35,7 @@ T = NaN(size(M.vertices,1),1);
 exp = [];
 act = spm_mesh_get_lm(M,T);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_get_lm_several(testCase)
 M = spm_mesh_polyhedron('icosahedron');
@@ -40,3 +44,7 @@ T = [1 NaN NaN NaN NaN NaN 7 8 9 10 11 12]';
 exp = [1 12];
 act = spm_mesh_get_lm(M,T);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_label.m
+++ b/tests/test_spm_mesh_label.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_label
+classdef test_spm_mesh_label < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_label
 %__________________________________________________________________________
 
 % Copyright (C) 2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_label_vertices(testCase)
@@ -18,7 +19,7 @@ testCase.verifyEqual(act, exp);
 act = size(C);
 exp = [sum(N) 1];
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_mesh_label_faces(testCase)
 P = export(gifti(fullfile(spm('Dir'),'canonical','cortex_8196.surf.gii')),'patch');
@@ -33,3 +34,7 @@ testCase.verifyEqual(act, exp);
 act = size(C);
 exp = [size(P.faces,1) 1];
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_laplacian.m
+++ b/tests/test_spm_mesh_laplacian.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_laplacian
+classdef test_spm_mesh_laplacian < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_laplacian
 %__________________________________________________________________________
 
 % Copyright (C) 2021-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_laplacian_sphere(testCase)
@@ -38,3 +39,7 @@ testCase.verifyEqual(act, exp);
 act = full(sum(Lm,2));
 tol = 1e-10;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_neighbours.m
+++ b/tests/test_spm_mesh_neighbours.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_neighbours
+classdef test_spm_mesh_neighbours < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_neighbours
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_neighbours_tetrahedron(testCase)
@@ -17,3 +18,7 @@ testCase.verifyEqual(act, exp);
 
 act = spm_mesh_neighbours(sparse(ones(4)-eye(4)));
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_normals.m
+++ b/tests/test_spm_mesh_normals.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_normals
+classdef test_spm_mesh_normals < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_normals
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_normals_1(testCase)
@@ -15,3 +16,7 @@ t = triangulation(M.faces,M.vertices);
 exp = -double(t.vertexNormal);
 act = spm_mesh_normals(M, true);
 testCase.verifyEqual(act, exp ,'AbsTol', 10*eps);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_ray_intersect.m
+++ b/tests/test_spm_mesh_ray_intersect.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_ray_intersect
+classdef test_spm_mesh_ray_intersect < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_ray_intersect
 %__________________________________________________________________________
 
 % Copyright (C) 2020-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_ray(testCase)
@@ -32,3 +33,7 @@ testCase.verifyEqual(act, exp);
 exp = [0 3];
 act = size(P);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_reduce.m
+++ b/tests/test_spm_mesh_reduce.m
@@ -1,17 +1,19 @@
-function tests = test_spm_mesh_reduce
+classdef test_spm_mesh_reduce < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_reduce
 %__________________________________________________________________________
 
 % Copyright (C) 2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_sphere(testCase)
 M = spm_mesh_sphere;
 m = spm_mesh_reduce(M,1000);
 testCase.verifyTrue(size(m.faces,1) <= 1000);
+end
 
 function test_spm_mesh_cortex(testCase)
 M = gifti(fullfile(spm('Dir'),'canonical','cortex_20484.surf.gii'));
@@ -20,3 +22,9 @@ for i=round(linspace(1000,size(M.faces,1),50))
     m = spm_mesh_reduce(M,i);
     testCase.verifyTrue(size(m.faces,1) <= i);
 end
+
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_refine.m
+++ b/tests/test_spm_mesh_refine.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_refine
+classdef test_spm_mesh_refine < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_refine
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_refine_polyhedron(testCase)
@@ -14,6 +15,7 @@ M = spm_mesh_refine(P);
 exp = 4*size(P.faces,1);
 act = size(M.faces,1);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_mesh_refine_gifti(testCase)
 P = gifti(fullfile(spm('Dir'),'canonical','cortex_8196.surf.gii'));
@@ -32,3 +34,7 @@ testCase.verifyEqual(act, exp);
 exp = size(P.cdata,2);
 act = size(M.cdata,2);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_sdf.m
+++ b/tests/test_spm_mesh_sdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_sdf
+classdef test_spm_mesh_sdf < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_sdf
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_sdf_(testCase)
@@ -22,3 +23,7 @@ testCase.verifySize(F,V.dim);
 testCase.verifyFalse(any(isnan(F(:))));
 testCase.verifyTrue(any(F(:)>0));
 testCase.verifyTrue(any(F(:)<0));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_smooth.m
+++ b/tests/test_spm_mesh_smooth.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_smooth
+classdef test_spm_mesh_smooth < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_smooth
 %__________________________________________________________________________
 
 % Copyright (C) 2020-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_smooth_1(testCase)
@@ -19,7 +20,7 @@ testCase.verifyEqual(act, exp);
 exp = K;
 act = spm_mesh_smooth(K);
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_mesh_smooth_2(testCase)
 
@@ -29,3 +30,7 @@ T = rand(size(M.vertices,1),1);
 T = spm_mesh_smooth(K,T,10);
 testCase.verifyTrue(min(T)>=0);
 testCase.verifyTrue(max(T)<=1);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_sphere.m
+++ b/tests/test_spm_mesh_sphere.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_sphere
+classdef test_spm_mesh_sphere < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_sphere
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_sphere_icosahedron(testCase)
@@ -47,7 +48,7 @@ testCase.verifyTrue(isstruct(M));
 exp = [10242 20480];
 act = [size(M.vertices,1) size(M.faces,1)];
 testCase.verifyEqual(act, exp);
-
+end
 
 function test_spm_mesh_sphere_octahedron(testCase)
 M = spm_mesh_sphere(0,spm_mesh_polyhedron('octahedron'));
@@ -61,3 +62,7 @@ testCase.verifyTrue(isstruct(M));
 exp = [4098 8192];
 act = [size(M.vertices,1) size(M.faces,1)];
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_mesh_volume.m
+++ b/tests/test_spm_mesh_volume.m
@@ -1,11 +1,12 @@
-function tests = test_spm_mesh_volume
+classdef test_spm_mesh_volume < matlab.unittest.TestCase
 % Unit Tests for spm_mesh_volume
 %__________________________________________________________________________
 
 % Copyright (C) 2021-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_mesh_volume_polyhedron(testCase)
@@ -30,7 +31,7 @@ testCase.verifyEqual(act, exp, 'AbsTol',1e-6);
 % exp = sqrt(2)/12*a^3;
 % act = spm_mesh_volume(M);
 % testCase.verifyEqual(act, exp, 'AbsTol',1e-6);
-
+end
 
 function test_spm_mesh_volume_sphere(testCase)
 
@@ -40,3 +41,7 @@ r = 1;
 exp = 4/3*pi*r^3;
 act = spm_mesh_volume(M);
 testCase.verifyEqual(act, exp, 'AbsTol',1e-2);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_ncFcdf.m
+++ b/tests/test_spm_ncFcdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_ncFcdf
+classdef test_spm_ncFcdf < matlab.unittest.TestCase
 % Unit Tests for spm_ncFcdf
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_ncFcdf_1(testCase)
@@ -23,6 +24,7 @@ exp = 0.571988250151978; % ncfcdf(2,2,10,2)
 act = spm_ncFcdf(2,[2,10],2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncFcdf_2(testCase)
 exp = [0 % ncfcdf(0:0.3:5,3,24,pi)
@@ -45,3 +47,7 @@ exp = [0 % ncfcdf(0:0.3:5,3,24,pi)
 act = spm_ncFcdf(0:0.3:5,[3,24],pi);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_ncFpdf.m
+++ b/tests/test_spm_ncFpdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_ncFpdf
+classdef test_spm_ncFpdf < matlab.unittest.TestCase
 % Unit Tests for spm_ncFpdf
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_ncFpdf_1(testCase)
@@ -23,6 +24,7 @@ exp = 0.187052298433871; % ncfpdf(2,2,10,2)
 act = spm_ncFpdf(2,[2,10],2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncFpdf_2(testCase)
 exp = [0 % ncfpdf(0:0.3:5,3,24,pi)
@@ -45,3 +47,7 @@ exp = [0 % ncfpdf(0:0.3:5,3,24,pi)
 act = spm_ncFpdf(0:0.3:5,[3,24],pi);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_ncTcdf.m
+++ b/tests/test_spm_ncTcdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_ncTcdf
+classdef test_spm_ncTcdf < matlab.unittest.TestCase
 % Unit Tests for spm_ncTcdf
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_ncTcdf_1(testCase)
@@ -13,36 +14,42 @@ exp = 0.5; % nctcdf(0,1,0)
 act = spm_ncTcdf(0,1,0);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_2(testCase)
 exp = 0.5; % nctcdf(0,4,0)
 act = spm_ncTcdf(0,4,0);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_3(testCase)
 exp = 0.022750131948179; % nctcdf(0,4,2)
 act = spm_ncTcdf(0,4,2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_4(testCase)
 exp = 4.218150123125319e-05; % nctcdf(-4,4,2)
 act = spm_ncTcdf(-4,4,2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_5(testCase)
 exp = 0.920822617476195; % nctcdf(5,4,2)
 act = spm_ncTcdf(5,4,2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_6(testCase)
 exp = 0.992600181884681; % nctcdf(10,4,2)
 act = spm_ncTcdf(10,4,2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTcdf_7(testCase)
 exp = [0.000000011096548  % nctcdf(-4:10,4,4)
@@ -63,3 +70,7 @@ exp = [0.000000011096548  % nctcdf(-4:10,4,4)
 act = spm_ncTcdf(-4:10,4,4);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_ncTpdf.m
+++ b/tests/test_spm_ncTpdf.m
@@ -1,11 +1,12 @@
-function tests = test_spm_ncTpdf
+classdef test_spm_ncTpdf < matlab.unittest.TestCase
 % Unit Tests for spm_ncTpdf
 %__________________________________________________________________________
 
 % Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_ncTpdf_1(testCase)
@@ -28,6 +29,7 @@ exp = spm_Tpdf(-2:2,1:5);
 act = spm_ncTpdf(-2:2,1:5,0);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
 
 function test_spm_ncTpdf_2(testCase)
 exp = 0.193064705260108; % nctpdf(0,1,1)
@@ -49,3 +51,7 @@ exp = [... % nctpdf(-1:3,6:10,-2:2);
 act = spm_ncTpdf(-1:3,6:10,-2:2);
 tol = 1e-12;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_openmp.m
+++ b/tests/test_spm_openmp.m
@@ -1,12 +1,13 @@
-function tests = test_spm_openmp
+classdef test_spm_openmp < matlab.unittest.TestCase
 % Unit Tests for OpenMP
 %__________________________________________________________________________
 
 % Copyright (C) 2019-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
-tests(1:end) = []; % ALL TESTS ARE DISABLED
+methods (Test, TestTags = {'Disabled'})
+
+% ALL TESTS ARE DISABLED - Use TestTags to skip these tests
 
 % Push returns different results because of the order of the summation.
 % No order is more right than the other, so it shouldn't be a problem.
@@ -26,18 +27,18 @@ fprintf('bsplinc\n');
 fprintf('----------\n');
 dim     = [100 100 100];
 i       = randn(dim, 'single');
-fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
 tic
 o = spm_diffeo('bsplinc', i, [7 7 7]);
 t1 = toc;
-fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
 tic
 oo = spm_diffeo('bsplinc', i, [7 7 7]);
 t2 = toc;
 fprintf('Speedup: %g\n', t1/t2);
 fprintf('Same output: %d\n', isequaln(o,oo));
 testCase.verifyEqual(o, oo);
-
+end
 
 function test_spm_openmp_diffeo_bsplins(testCase)
 fprintf('\n');
@@ -51,18 +52,18 @@ id        = cell(3,1);
 [id{1:3}] = ndgrid(single(1:dimo(1)),single(1:dimo(2)),single(1:dimo(3)));
 id        = cat(4,id{:});
 y         = (id -1)*0.5 + 1;
-fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
 tic
 o = spm_diffeo('bsplins', i, y, [7 7 7]);
 t1 = toc;
-fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
 tic
 oo = spm_diffeo('bsplins', i, y, [7 7 7]);
 t2 = toc;
 fprintf('Speedup: %g\n', t1/t2);
 fprintf('Same output: %d\n', isequaln(o,oo));
 testCase.verifyEqual(o, oo);
-
+end
 
 function test_spm_openmp_diffeo_pull(testCase)
 fprintf('\n');
@@ -76,18 +77,18 @@ id        = cell(3,1);
 [id{1:3}] = ndgrid(single(1:dimo(1)),single(1:dimo(2)),single(1:dimo(3)));
 id        = cat(4,id{:});
 y         = (id -1)*0.5 + 1;
-fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
 tic
 o = spm_diffeo('pullc', i, y);
 t1 = toc;
-fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
 tic
 oo = spm_diffeo('pullc', i, y);
 t2 = toc;
 fprintf('Speedup: %g\n', t1/t2);
 fprintf('Same output: %d\n', isequaln(o,oo));
 testCase.verifyEqual(o, oo);
-
+end
 
 function test_spm_openmp_diffeo_push(testCase)
 fprintf('\n');
@@ -101,11 +102,11 @@ id        = cell(3,1);
 [id{1:3}] = ndgrid(single(1:dimi(1)),single(1:dimi(2)),single(1:dimi(3)));
 id        = cat(4,id{:});
 y         = (id -1)*0.5 + 1;
-fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
 tic
 [o,c] = spm_diffeo('pushc', i, y, dimo);
 t1 = toc;
-fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
 tic
 [oo,cc] = spm_diffeo('pushc', i, y, dimo);
 t2 = toc;
@@ -114,7 +115,7 @@ fprintf('Same output: %d\n', isequaln(o,oo) && isequal(c,cc));
 tol = single(1E-5);
 testCase.verifyEqual(o, oo,'AbsTol',tol);
 testCase.verifyEqual(c, cc,'AbsTol',tol);
-
+end
 
 function test_spm_openmp_field_vel2mom(testCase)
 fprintf('\n');
@@ -124,19 +125,20 @@ fprintf('----------\n');
 dim = [200 200 200];
 i   = ones([dim 3], 'single');
 for bnd=[0 1]
-    spm_field('boundary', bnd);
+    test_spm_openmp.spm_field('boundary', bnd);
     fprintf('* boundary: %d\n', bnd);
-    fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
     tic
-    o = spm_field('vel2mom',i,[1 1 1 10 100 10000]);
+    o = test_spm_openmp.spm_field('vel2mom',i,[1 1 1 10 100 10000]);
     t1 = toc;
-    fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
     tic
-    oo = spm_field('vel2mom',i,[1 1 1 10 100 10000]);
+    oo = test_spm_openmp.spm_field('vel2mom',i,[1 1 1 10 100 10000]);
     t2 = toc;
-    fprintf('Speedup: %g\n', t1/t2);
-    fprintf('Same output: %d\n', isequaln(o,oo));
-    testCase.verifyEqual(o, oo);
+fprintf('Speedup: %g\n', t1/t2);
+fprintf('Same output: %d\n', isequaln(o,oo));
+testCase.verifyEqual(o, oo);
+end
 end
 
 
@@ -148,19 +150,20 @@ fprintf('----------\n');
 dim = [200 200 200];
 i   = ones([dim 3], 'single');
 for bnd=[0 1]
-    spm_diffeo('boundary', bnd);
+    test_spm_openmp.spm_diffeo('boundary', bnd);
     fprintf('* boundary: %d\n', bnd);
-    fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
     tic
-    o = spm_diffeo('vel2mom',i,[1 1 1 10 100 10000 10 10]);
+    o = test_spm_openmp.spm_diffeo('vel2mom',i,[1 1 1 10 100 10000 10 10]);
     t1 = toc;
-    fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
     tic
-    oo = spm_diffeo('vel2mom',i,[1 1 1 10 100 10000 10 10]);
+    oo = test_spm_openmp.spm_diffeo('vel2mom',i,[1 1 1 10 100 10000 10 10]);
     t2 = toc;
-    fprintf('Speedup: %g\n', t1/t2);
-    fprintf('Same output: %d\n', isequaln(o,oo));
-    testCase.verifyEqual(o, oo);
+fprintf('Speedup: %g\n', t1/t2);
+fprintf('Same output: %d\n', isequaln(o,oo));
+testCase.verifyEqual(o, oo);
+end
 end
 
 
@@ -173,19 +176,20 @@ dim = [200 200 200];
 H   = cat(4, ones([dim 3], 'single'), 1E-5*ones([dim 3], 'single'));
 g   = randn([dim 3], 'single');
 for bnd=[0 1]
-    spm_field('boundary', bnd);
+    test_spm_openmp.spm_field('boundary', bnd);
     fprintf('* boundary: %d\n', bnd);
-    fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
     tic
-    o = spm_field(H,g,[1 1 1 10 100 10000 2 2]);
+    o = test_spm_openmp.spm_field(H,g,[1 1 1 10 100 10000 2 2]);
     t1 = toc;
-    fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
     tic
-    oo = spm_field(H,g,[1 1 1 10 100 10000 2 2]);
+    oo = test_spm_openmp.spm_field(H,g,[1 1 1 10 100 10000 2 2]);
     t2 = toc;
-    fprintf('Speedup: %g\n', t1/t2);
-    fprintf('Same output: %d\n', isequaln(o,oo));
-    testCase.verifyEqual(o, oo);
+fprintf('Speedup: %g\n', t1/t2);
+fprintf('Same output: %d\n', isequaln(o,oo));
+testCase.verifyEqual(o, oo);
+end
 end
 
 
@@ -198,23 +202,32 @@ dim = [200 200 200];
 H   = cat(4, ones([dim 3], 'single'), 1E-5*ones([dim 3], 'single'));
 g   = randn([dim 3], 'single');
 for bnd=[0 1]
-    spm_diffeo('boundary', bnd);
+    test_spm_openmp.spm_diffeo('boundary', bnd);
     fprintf('* boundary: %d\n', bnd);
-    fprintf('Number of threads: %d\n', spm_set_num_threads(1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(1));
     tic
-    o = spm_diffeo('fmg',H,g,[1 1 1 10 100 10000 10 10 2 2]);
+    o = test_spm_openmp.spm_diffeo('fmg',H,g,[1 1 1 10 100 10000 10 10 2 2]);
     t1 = toc;
-    fprintf('Number of threads: %d\n', spm_set_num_threads(-1));
+    fprintf('Number of threads: %d\n', test_spm_openmp.spm_set_num_threads(-1));
     tic
-    oo = spm_diffeo('fmg',H,g,[1 1 1 10 100 10000 10 10 2 2]);
-    t2 = toc;
-    fprintf('Speedup: %g\n', t1/t2);
-    fprintf('Same output: %d\n', isequaln(o,oo));
-    testCase.verifyEqual(o, oo);
+    oo = test_spm_openmp.spm_diffeo('fmg',H,g,[1 1 1 10 100 10000 10 10 2 2]);
+t2 = toc;
+fprintf('Speedup: %g\n', t1/t2);
+fprintf('Same output: %d\n', isequaln(o,oo));
+testCase.verifyEqual(o, oo);
+end
 end
 
+end % methods (Test)
 
+% Helper methods
+methods (Static, Access = private)
 function n = spm_set_num_threads(n)
 setenv('SPM_NUM_THREADS',sprintf('%d',n));
 try, spm_diffeo; end
 n = sscanf(getenv('SPM_NUM_THREADS'),'%d');
+end
+
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_opm_create.m
+++ b/tests/test_spm_opm_create.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_create
+classdef test_spm_opm_create < matlab.unittest.TestCase
 % Unit Tests for spm_opm_hfc
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_create_1(testCase)
@@ -23,5 +24,7 @@ test = -1.8334e4;
 act = round(D(111,5));
 
 testCase.verifyTrue((test-act)< 1e-6);
+end
+end % methods (Test)
 
-
+end % classdef

--- a/tests/test_spm_opm_epoch_trigger.m
+++ b/tests/test_spm_opm_epoch_trigger.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_epoch_trigger
+classdef test_spm_opm_epoch_trigger < matlab.unittest.TestCase
 % Unit Tests for spm_eeg_average
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_epoch_trigger_1(testCase)
@@ -31,3 +32,7 @@ eD=spm_opm_epoch_trigger(S);
 exp = 3;
 act = size(eD,3);
 testCase.verifyTrue(isequal(exp, act));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_opm_headmodel.m
+++ b/tests/test_spm_opm_headmodel.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_headmodel
+classdef test_spm_opm_headmodel < matlab.unittest.TestCase
 % Unit Tests for spm_opm_headmodel
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_headmodel_1(testCase)
@@ -35,3 +36,7 @@ expected = 50;
 
 % check dimensionality > 50
 testCase.verifyTrue(observed>=expected);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_opm_hfc.m
+++ b/tests/test_spm_opm_hfc.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_hfc
+classdef test_spm_opm_hfc < matlab.unittest.TestCase
 % Unit Tests for spm_opm_hfc
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_hfc_1(testCase)
@@ -44,3 +45,7 @@ res = std(squeeze(hD(:,:,1)),[],2);
 ratio = mean(Y./res);
 
 testCase.verifyTrue(ratio>100);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_opm_psd.m
+++ b/tests/test_spm_opm_psd.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_psd
+classdef test_spm_opm_psd < matlab.unittest.TestCase
 % Unit Tests for spm_opm_psd
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_psd_1(testCase)
@@ -28,3 +29,7 @@ S.plot=0;
 act = mean(mean(p))*sqrt(1000);
 
 testCase.verifyTrue(act>.85);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_opm_rpsd.m
+++ b/tests/test_spm_opm_rpsd.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_rpsd
+classdef test_spm_opm_rpsd < matlab.unittest.TestCase
 % Unit Tests for spm_opm_rpsd
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_rpsd_1(testCase)
@@ -36,3 +37,7 @@ D2.delete();
 
 % test  for at least 9 dB of shielding
 testCase.verifyTrue(act < -9);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_opm_sim.m
+++ b/tests/test_spm_opm_sim.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_sim
+classdef test_spm_opm_sim < matlab.unittest.TestCase
 % Unit Tests for spm_opm_sim
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_sim_1(testCase)
@@ -31,7 +32,7 @@ testCase.verifyTrue(isequal(exp, act));
 exp = size(D,1);
 act = size(L,1);
 testCase.verifyTrue(isequal(exp, act));
+end
+end % methods (Test)
 
-
-
-
+end % classdef

--- a/tests/test_spm_opm_vslm.m
+++ b/tests/test_spm_opm_vslm.m
@@ -1,11 +1,12 @@
-function tests = test_spm_opm_vslm
+classdef test_spm_opm_vslm < matlab.unittest.TestCase
 % Unit Tests for spm_opm_vslm
 %__________________________________________________________________________
 
 % Copyright (C) 2023 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_opm_vslm_1(testCase)
@@ -62,3 +63,7 @@ H= [H,L3];
 act = sum(cs);
 
 testCase.verifyTrue(((15-act)/15) < 1e-5);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_platform.m
+++ b/tests/test_spm_platform.m
@@ -1,11 +1,12 @@
-function tests = test_spm_platform
+classdef test_spm_platform < matlab.unittest.TestCase
 % Unit Tests for spm_platform
 %__________________________________________________________________________
 
 % Copyright (C) 2020-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_platform_init(testCase)
@@ -16,6 +17,7 @@ p = spm_platform;
 testCase.verifyThat(p, IsOfClass('struct'));
 p = spm_platform('init');
 testCase.verifyThat(p, IsOfClass('struct'));
+end
 
 function test_spm_platform_query(testCase)
 import matlab.unittest.constraints.*
@@ -30,6 +32,7 @@ val = spm_platform('tempdir');
 testCase.verifyThat(val, IsOfClass('char'));
 val = spm_platform('desktop');
 testCase.verifyThat(val, IsOfClass('logical'));
+end
 
 function test_spm_platform_fonts(testCase)
 import matlab.unittest.constraints.*
@@ -44,6 +47,7 @@ font = spm_platform('font','courier');
 testCase.verifyThat(font, IsOfClass('char'));
 font = spm_platform('font','symbol');
 testCase.verifyThat(font, IsOfClass('char'));
+end
 
 function test_spm_platform_memory(testCase)
 import matlab.unittest.constraints.*
@@ -54,3 +58,7 @@ meminfo = spm_platform('memory','available');
 testCase.verifyThat(meminfo, IsOfClass('double'));
 meminfo = spm_platform('memory','total');
 testCase.verifyThat(meminfo, IsOfClass('double'));
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_plot_ci.m
+++ b/tests/test_spm_plot_ci.m
@@ -1,25 +1,26 @@
-function tests = test_spm_plot_ci
+classdef test_spm_plot_ci < matlab.unittest.TestCase
 % Unit Tests for spm_plot_ci
 % Ensures that all the different plot types run without error
 %__________________________________________________________________________
 
 % Copyright (C) 2016-2022 Wellcome Centre for Human Neuroimaging
 
-
-tests = functiontests(localfunctions);
+methods (Test)
 
 function test_barchart(testCase)
 
 E = (1:5)';
 C = [1 1 1 1/4 1/4]';
 
-do_plot(E,C);
+test_spm_plot_ci.do_plot(E,C);
+end
 
 function test_barchart_exp(testCase)
 
 E = (1:5)';
 C = [1 1 1 1/4 1/4]';
-do_plot(E,C,'exp');
+test_spm_plot_ci.do_plot(E,C,'exp');
+end
 
 function test_grouped_barchart(testCase)
 
@@ -27,7 +28,8 @@ E = [1 2 3 4 5
      6 7 8 9 10]';
 C = [1   1   1 1/4 1/4;
      1/4 1/4 1 1   1]';
-do_plot(E,C);
+test_spm_plot_ci.do_plot(E,C);
+end
 
 function test_grouped_barchart_exp(testCase)
 
@@ -35,21 +37,27 @@ E = [1 2 3 4 5
      6 7 8 9 10]';
 C = [1   1   1 1/4 1/4;
      1/4 1/4 1 1   1]';
-do_plot(E,C,'exp');
+test_spm_plot_ci.do_plot(E,C,'exp');
+end
 
 function test_confidence_region(testCase)
 
 E = [3 4];
 C = [1 1/4];
-do_plot(E,C);
+test_spm_plot_ci.do_plot(E,C);
+end
 
 function test_linechart(testCase)
 
 rng(1);
 E = randn(3,8); % At least 8 columns (i.e., measurements)
 C = exp(randn(3,8));
-do_plot(E,C);
+test_spm_plot_ci.do_plot(E,C);
+end
 
+end % methods (Test)
+
+methods (Static, Access = private)
 function do_plot(E,C,str)
 % Run spm_plot_ci within a figure
 f=figure;
@@ -59,3 +67,7 @@ else
     spm_plot_ci(E,C,[],[],str);
 end
 close(f);
+end
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_run_dcm_bms.m
+++ b/tests/test_spm_run_dcm_bms.m
@@ -1,4 +1,4 @@
-function tests = test_spm_run_dcm_bms
+classdef test_spm_run_dcm_bms < matlab.unittest.TestCase
 % Unit Tests for config/spm_run_dcm_bms. Tests are provided with and
 % without evidence for a particular model with artificially generated free
 % energies. Additionally, tests are included using real DCM files for
@@ -7,20 +7,22 @@ function tests = test_spm_run_dcm_bms
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
+methods (TestMethodSetup)
+    function setup(testCase)
+        % Prepare output directory
+        out_dir = test_spm_run_dcm_bms.get_output_dir();
 
-tests = functiontests(localfunctions);
-
-function setup(testCase)
-% Prepare output directory
-out_dir = get_output_dir();
-
-% Delete existing files if they exist
-if exist(fullfile(out_dir,'BMS.mat'),'file')
-    delete(fullfile(out_dir,'BMS.mat'));
+        % Delete existing files if they exist
+        if exist(fullfile(out_dir,'BMS.mat'),'file')
+            delete(fullfile(out_dir,'BMS.mat'));
+        end
+        if exist(fullfile(out_dir,'F.mat'),'file')
+            delete(fullfile(out_dir,'F.mat'));
+        end
+    end
 end
-if exist(fullfile(out_dir,'F.mat'),'file')
-    delete(fullfile(out_dir,'F.mat'));
-end
+
+methods (Test)
 
 % -------------------------------------------------------------------------
 function test_ffx_fmri_dcm(testCase)
@@ -35,11 +37,13 @@ P2 = spm_select('FPList',models_path,'DCM_.*_m2\.mat$');
 P  = [cellstr(P1)  cellstr(P2)];
 
 % Run FFX BMS
-run_bms_dcm_files('FFX', P);
+test_spm_run_dcm_bms.run_bms_dcm_files('FFX', P);
 
 % Check
-load(fullfile(get_output_dir(), 'BMS.mat'));
+load(fullfile(test_spm_run_dcm_bms.get_output_dir(), 'BMS.mat'));
 testCase.assertTrue(BMS.DCM.ffx.model.post(2) > 0.99);
+end
+
 % -------------------------------------------------------------------------
 function test_ffx_csd_dcm(testCase)
 % Tests that the BMS can run on a CSD DCM
@@ -53,11 +57,13 @@ P2 = spm_select('FPList',models_path,'DCM_CSD.mat');
 P  = [cellstr(P1)  cellstr(P2)];
 
 % Run FFX BMS
-run_bms_dcm_files('FFX', P);
+test_spm_run_dcm_bms.run_bms_dcm_files('FFX', P);
 
 % Check
-load(fullfile(get_output_dir(), 'BMS.mat'));
+load(fullfile(test_spm_run_dcm_bms.get_output_dir(), 'BMS.mat'));
 testCase.assertTrue(BMS.DCM.ffx.model.post(2) == 0.5);
+end
+
 % -------------------------------------------------------------------------
 function test_rfx_no_evidence(testCase)
 % Tests RFX BMS in the context of equal model probabilities
@@ -93,11 +99,11 @@ F_gen  = mean_F + std_F .* randn(sum(m(:) > 0),1);
 F    = -13 + randn(n,4);
 F(m > 0) = F_gen;
 
-out_dir = get_output_dir();
+out_dir = test_spm_run_dcm_bms.get_output_dir();
 save(fullfile(out_dir,'F.mat'),'F');
 
 % Run
-run_bms_Fmatrix('RFX');
+test_spm_run_dcm_bms.run_bms_Fmatrix('RFX');
 
 % Load
 BMS=load(fullfile(out_dir,'BMS.mat'));
@@ -111,6 +117,8 @@ testCase.verifyThat(actual, IsEqualTo(r, 'Within', AbsoluteTolerance(0.1) ) );
 actual = BMS.DCM.rfx.model.bor;
 testCase.verifyThat(actual, IsGreaterThanOrEqualTo(0.9 ) );
 
+end
+
 % -------------------------------------------------------------------------
 function test_rfx_strong_evidence(testCase)
 % Tests RFX BMS in the context of an effect
@@ -119,7 +127,7 @@ function test_rfx_strong_evidence(testCase)
 import matlab.unittest.constraints.*
 rng('default');
 rng(1);
-out_dir = get_output_dir();
+out_dir = test_spm_run_dcm_bms.get_output_dir();
 
 n = 20;      % Subjects
 models = 4;  % Models per subject
@@ -149,7 +157,7 @@ F(m > 0) = F_gen;
 save(fullfile(out_dir,'F.mat'),'F');
 
 % Run
-run_bms_Fmatrix('RFX');
+test_spm_run_dcm_bms.run_bms_Fmatrix('RFX');
 
 % Load
 BMS=load(fullfile(out_dir,'BMS.mat'));
@@ -163,12 +171,14 @@ testCase.verifyThat(actual, IsEqualTo(r, 'Within', AbsoluteTolerance(0.1) ) );
 actual = BMS.DCM.rfx.model.bor;
 testCase.verifyThat(actual, IsLessThanOrEqualTo(0.1 ) );
 
+end
+
 % -------------------------------------------------------------------------
 function test_ffx_strong_evidence(testCase)
 % Tests FFX in the context of strong evidence
 
 import matlab.unittest.constraints.*
-out_dir = get_output_dir();
+out_dir = test_spm_run_dcm_bms.get_output_dir();
 
 % Free energies for model 1 and model 2
 F = [-10.3 -10.3 -10.3 -10.3 -10.3;
@@ -176,7 +186,7 @@ F = [-10.3 -10.3 -10.3 -10.3 -10.3;
 save(fullfile(out_dir,'F.mat'),'F');
 
 % Run
-run_bms_Fmatrix('FFX');
+test_spm_run_dcm_bms.run_bms_Fmatrix('FFX');
 
 % Check    
 BMS=load(fullfile(out_dir,'BMS.mat'));
@@ -190,12 +200,14 @@ testCase.verifyThat(actual_group_log_bf(2), ...
 testCase.verifyThat(actual_PP, ...
     IsEqualTo(0.95, 'Within', AbsoluteTolerance(0.01)));
 
+end
+
 % -------------------------------------------------------------------------
 function test_ffx_no_evidence(testCase)
 % Tests FFX in the context of no evidence
 
 import matlab.unittest.constraints.*
-out_dir = get_output_dir();
+out_dir = test_spm_run_dcm_bms.get_output_dir();
 
 % Free energies for model 1 and model 2
 F = [-10 -10 -10 -10 -10
@@ -203,7 +215,7 @@ F = [-10 -10 -10 -10 -10
 save(fullfile(out_dir,'F.mat'),'F');
 
 % Run
-run_bms_Fmatrix('FFX');
+test_spm_run_dcm_bms.run_bms_Fmatrix('FFX');
 
 % Check    
 BMS=load(fullfile(out_dir,'BMS.mat'));
@@ -217,10 +229,16 @@ testCase.verifyThat(actual_group_log_bf(2), ...
 testCase.verifyThat(actual_PP, ...
     IsEqualTo(0.5, 'Within', AbsoluteTolerance(0.01)));
 
+end
+
+end % methods (Test)
+
+
+methods (Static, Access = private)
 % -------------------------------------------------------------------------
 function run_bms_Fmatrix(method)
 % Run BMS using saved log evidence matrix
-out_dir = get_output_dir();
+out_dir = test_spm_run_dcm_bms.get_output_dir();
 clear matlabbatch;
 matlabbatch{1}.spm.dcm.bms.inference.dir = {out_dir};
 matlabbatch{1}.spm.dcm.bms.inference.sess_dcm = {};
@@ -231,6 +249,8 @@ matlabbatch{1}.spm.dcm.bms.inference.family_level.family_file = {''};
 matlabbatch{1}.spm.dcm.bms.inference.bma.bma_no = 0;
 matlabbatch{1}.spm.dcm.bms.inference.verify_id = 1;
 spm_jobman('run',matlabbatch);
+end
+
 % -------------------------------------------------------------------------
 function run_bms_dcm_files(method, P)
 % Run BMS using DCM .mat files
@@ -238,7 +258,7 @@ function run_bms_dcm_files(method, P)
 % P - subjects x models cell array
 
 clear matlabbatch;
-matlabbatch{1}.spm.dcm.bms.inference.dir = cellstr(get_output_dir());
+matlabbatch{1}.spm.dcm.bms.inference.dir = cellstr(test_spm_run_dcm_bms.get_output_dir());
 matlabbatch{1}.spm.dcm.bms.inference.model_sp = {''};
 matlabbatch{1}.spm.dcm.bms.inference.load_f = {''};
 matlabbatch{1}.spm.dcm.bms.inference.method = method;
@@ -251,6 +271,8 @@ for s = 1:size(P,1)
 end
 spm_jobman('run',matlabbatch);
 
+end
+
 % -------------------------------------------------------------------------
 function out_dir = get_output_dir()
 % Returns the directory for output files and creates it if needed
@@ -258,3 +280,8 @@ out_dir = fullfile( spm('Dir'), 'tests', 'output');
 if ~exist(out_dir,'file')
     mkdir(out_dir);
 end
+end
+
+end % methods (Static, Access = private)
+
+end % classdef

--- a/tests/test_spm_sum.m
+++ b/tests/test_spm_sum.m
@@ -1,11 +1,12 @@
-function tests = test_spm_sum
+classdef test_spm_sum < matlab.unittest.TestCase
 % Unit Tests for spm_sum
 %__________________________________________________________________________
 
 % Copyright (C) 2020-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_sum_1(testCase)
@@ -22,6 +23,7 @@ testCase.verifyEqual(act, exp);
 exp = 25*26/2;
 act = spm_sum(X,[1 2]);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_sum_2(testCase)
 X = 1:10;
@@ -46,6 +48,7 @@ testCase.verifyEqual(act, exp);
 exp = sum(X(:));
 act = spm_sum(X,[3 1 2]);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_sum_3(testCase)
 X = (1:10)';
@@ -70,6 +73,7 @@ testCase.verifyEqual(act, exp);
 exp = sum(X(:));
 act = spm_sum(X,[3 1 2]);
 testCase.verifyEqual(act, exp);
+end
 
 function test_spm_sum_4(testCase)
 X = [magic(5);1:5];
@@ -104,3 +108,7 @@ testCase.verifyEqual(act, exp);
 exp = spm_sum(X,[1 2 3]);
 act = spm_sum(X,[2 1 3]);
 testCase.verifyEqual(act, exp);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_trace.m
+++ b/tests/test_spm_trace.m
@@ -1,11 +1,12 @@
-function tests = test_spm_trace
+classdef test_spm_trace < matlab.unittest.TestCase
 % Unit Tests for spm_trace
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_trace_trace(testCase)
@@ -16,7 +17,7 @@ exp = trace(A*B);
 act = spm_trace(A,B);
 tol = 1e-6;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_trace_sum(testCase)
 A = rand(3);
@@ -26,7 +27,7 @@ exp = sum(sum(A'.*B));
 act = spm_trace(A,B);
 tol = 1e-6;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_trace_nonsquare_1(testCase)
 A = rand(3,5);
@@ -36,7 +37,7 @@ exp = trace(A*B);
 act = spm_trace(A,B);
 tol = 1e-6;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_trace_nonsquare_2(testCase)
 A = rand(5,3);
@@ -46,3 +47,7 @@ exp = trace(A*B);
 act = spm_trace(A,B);
 tol = 1e-6;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_update.m
+++ b/tests/test_spm_update.m
@@ -1,11 +1,12 @@
-function tests = test_spm_update
+classdef test_spm_update < matlab.unittest.TestCase
 % Unit Tests for spm_update
 %__________________________________________________________________________
 
 % Copyright (C) 2017-2025 Wellcome Centre for Human Neuroimaging
 
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_version_check(testCase)
@@ -32,3 +33,8 @@ if all(failed)
     disp(sts);
     disp(msg);
 end
+end
+
+end % methods (Test)
+
+end % classdef

--- a/tests/test_spm_z2p.m
+++ b/tests/test_spm_z2p.m
@@ -1,10 +1,11 @@
-function tests = test_spm_z2p
+classdef test_spm_z2p < matlab.unittest.TestCase
 % Unit Tests for spm_z2p
 %__________________________________________________________________________
 
 % Copyright (C) 2015-2022 Wellcome Centre for Human Neuroimaging
 
-tests = functiontests(localfunctions);
+
+methods (Test)
 
 
 function test_spm_z2p_Z(testCase)
@@ -12,31 +13,35 @@ exp = 0.05;
 act = spm_z2p(1.644853626951472,[],'Z');
 tol = 1e-8;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_z2p_T(testCase)
 exp = 0.05;
 act = spm_z2p(1.745883689098006,[1 16],'T');
 tol = 1e-8;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_z2p_X(testCase)
 exp = 0.05;
 act = spm_z2p(26.296227607876062,[1 16],'X');
 tol = 1e-8;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_z2p_F(testCase)
 exp = 0.05;
 act = spm_z2p(3.633723519202212,[2 16],'F');
 tol = 1e-8;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
-
+end
 
 function test_spm_z2p_P(testCase)
 exp = 0.5;
 act = spm_z2p(0.5,[],'P');
 tol = 1e-8;
 testCase.verifyEqual(act, exp,'AbsTol',tol);
+end
+end % methods (Test)
+
+end % classdef


### PR DESCRIPTION
All tests are converted to class-based tests. The testing code is kept identical, only class information is added.

New Workflow that runs the tests for the standalone after release and can be triggered manually.

- The tests are a bit faster (466s -> 305s), because matlab parallelizes class based tests.
- Deactivating tests is now done by adding the 'Disabled' tag (see test_checkcode/test_analyzeCodeCompatibility)
- Changed test_gifti.m to use a file from canonical folder instead of load('mri'), which isn't available in standalone
- Added Signal Processing Toolbox in standalone compilation (test_spm_eeg_filter/test_spm_eeg_filter_1 requires it)
- Deactivated test_checkcode for standalone (checkcode function is only available in full matlab)
- Added 'test' command for standalone