### PR TITLE
Bug fix: DCM A-matrix labels now keyed on neural model

### DIFF
--- a/toolbox/dcm_meeg/spm_dcm_csd_results.m
+++ b/toolbox/dcm_meeg/spm_dcm_csd_results.m
@@ -163,8 +163,25 @@ case{lower('Coupling (A)')}
     
     % spm_dcm_csd_results(DCM,'coupling (A)');
     %----------------------------------------------------------------------
-    str = {'Forward (i)','Forward (ii)','Backward (i)','Backward (ii)'};
+    if ~isfield(DCM.Ep,'A'), return, end
     m   = length(DCM.Ep.A);
+    try, model = DCM.options.model; catch, model = ''; end
+    switch upper(model)
+        case {'ERP','SEP','LFP','NMM','MFM','NMDA'}
+            str = {'Forward','Backward','Lateral'};
+        case {'CMM','CMM_NMDA'}
+            str = {'Forward','Backward'};
+        case {'CMC','TFM'}
+            str = {'Forward (i)','Forward (ii)', ...
+                   'Backward (i)','Backward (ii)'};
+        case 'MMC'
+            str = {'Forward (sp->mp)','Forward (sp->sp)', ...
+                   'Backward (dp->dp)'};
+        otherwise
+            str = {};
+    end
+    for k = numel(str)+1:m, str{k} = sprintf('A{%d}',k); end
+    str = str(1:m);
     for  i = 1:m
         
         % images

--- a/toolbox/dcm_meeg/spm_dcm_erp_results.m
+++ b/toolbox/dcm_meeg/spm_dcm_erp_results.m
@@ -244,13 +244,23 @@ switch(lower(Action))
         %------------------------------------------------------------------
         if ~isfield(DCM.Ep,'A'), return, end
         n    = length(DCM.Ep.A);
-        if n == 2
-            str = {'Forward','Backward'};
-        elseif n == 3
-            str = {'Forward','Backward','Lateral'};
-        else
-            str = {'Forward (i)','Forward (ii)','Backward (i)','Backward (ii)'};
+        try, model = DCM.options.model; catch, model = ''; end
+        switch upper(model)
+            case {'ERP','SEP','LFP','NMM','MFM','NMDA'}
+                str = {'Forward','Backward','Lateral'};
+            case {'CMM','CMM_NMDA'}
+                str = {'Forward','Backward'};
+            case {'CMC','TFM'}
+                str = {'Forward (i)','Forward (ii)', ...
+                       'Backward (i)','Backward (ii)'};
+            case 'MMC'
+                str = {'Forward (sp->mp)','Forward (sp->sp)', ...
+                       'Backward (dp->dp)'};
+            otherwise
+                str = {};
         end
+        for k = numel(str)+1:n, str{k} = sprintf('A{%d}',k); end
+        str = str(1:n);
         
         for i = 1:n
             

--- a/toolbox/dcm_meeg/spm_dcm_ssr_results.m
+++ b/toolbox/dcm_meeg/spm_dcm_ssr_results.m
@@ -108,12 +108,30 @@ case{lower('Coupling (A)')}
     
     % spm_dcm_ssr_results(DCM,'coupling (A)');
     %----------------------------------------------------------------------
-    str = {'Forward','Backward','Lateral'};
-    for  i = 1:3
-        
+    if ~isfield(DCM.Ep,'A'), return, end
+    m   = length(DCM.Ep.A);
+    try, model = DCM.options.model; catch, model = ''; end
+    switch upper(model)
+        case {'ERP','SEP','LFP','NMM','MFM','NMDA'}
+            str = {'Forward','Backward','Lateral'};
+        case {'CMM','CMM_NMDA'}
+            str = {'Forward','Backward'};
+        case {'CMC','TFM'}
+            str = {'Forward (i)','Forward (ii)', ...
+                   'Backward (i)','Backward (ii)'};
+        case 'MMC'
+            str = {'Forward (sp->mp)','Forward (sp->sp)', ...
+                   'Backward (dp->dp)'};
+        otherwise
+            str = {};
+    end
+    for k = numel(str)+1:m, str{k} = sprintf('A{%d}',k); end
+    str = str(1:m);
+    for  i = 1:m
+
         % images
         %------------------------------------------------------------------
-        subplot(4,3,i)
+        subplot(4,m,i)
         imagesc(exp(DCM.Ep.A{i}))
         title(str{i},'FontSize',10)
         set(gca,'YTick',[1:ns],'YTickLabel',DCM.Sname,'FontSize',8)
@@ -121,29 +139,29 @@ case{lower('Coupling (A)')}
         xlabel('from','FontSize',8)
         ylabel('to','FontSize',8)
         axis square
-    
+
         % table
         %------------------------------------------------------------------
-        subplot(4,3,i + 3)
+        subplot(4,m,i + m)
         text(0,1/2,num2str(full(exp(DCM.Ep.A{i})),' %.2f'),'FontSize',8)
         axis off,axis square
- 
-    
+
+
         % PPM
         %------------------------------------------------------------------
-        subplot(4,3,i + 6)
+        subplot(4,m,i + 2*m)
         image(64*DCM.Pp.A{i})
         set(gca,'YTick',[1:ns],'YTickLabel',DCM.Sname,'FontSize',8)
         set(gca,'XTick',[])
         title('PPM')
         axis square
-    
+
         % table
         %------------------------------------------------------------------
-        subplot(4,3,i + 9)
+        subplot(4,m,i + 3*m)
         text(0,1/2,num2str(DCM.Pp.A{i},' %.2f'),'FontSize',8)
         axis off, axis square
-        
+
     end
     
 case{lower('Coupling (C)')}


### PR DESCRIPTION
Closes: https://github.com/spm/spm/issues/130.

- Replace hard-coded A-matrix labels in `spm_dcm_csd_results.m`, `spm_dcm_erp_results.m`, and `spm_dcm_ssr_results.m` with a switch on `DCM.options.model`, picking the connection names documented in each `spm_fx_*.m`:
  - ERP / SEP / LFP / NMM / MFM / NMDA → Forward, Backward, Lateral
  - CMM / CMM_NMDA → Forward, Backward
  - CMC / TFM → Forward (i)/(ii), Backward (i)/(ii)
  - MMC → Forward (sp->mp), Forward (sp->sp), Backward (dp->dp)
  - unknown model → generic `A{k}` fallback
- Add a `~isfield(DCM.Ep,'A')` guard before reading `DCM.Ep.A`.
- In `spm_dcm_ssr_results.m`, also replace the hard-coded `for i = 1:3` loop bound and `subplot(4,3,...)` indices with `length(DCM.Ep.A)`, so non-3-matrix models (CMM with 2, CMC with 4) no longer mis-plot or index past the end of `DCM.Ep.A`.
