### PR TITLE
Enhancement: DCM convergence reporting

### DIFF
--- a/spm_dcm_estimate.m
+++ b/spm_dcm_estimate.m
@@ -262,7 +262,11 @@ if ~DCM.options.stochastic
     
     % nonlinear system identification (Variational EM) - deterministic DCM
     %----------------------------------------------------------------------
-    [Ep,Cp,Eh,F] = spm_nlsi_GN(M,U,Y);
+    [Ep,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(M,U,Y);
+
+    DCM.convergence.converged = converged;
+    DCM.convergence.F         = Fhist.F;
+    DCM.convergence.L         = Fhist.L;
     
     % predicted responses (y) and residuals (R)
     %----------------------------------------------------------------------

--- a/spm_dcm_fmri_csd.m
+++ b/spm_dcm_fmri_csd.m
@@ -243,7 +243,11 @@ DCM.Y.X0 = sparse(size(DCM.Y.Q,1),0);
 %==========================================================================
 Y            = DCM.Y;
 Y.y          = DCM.Y.csd;
-[Ep,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.U,Y);
+[Ep,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.U,Y);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Bayesian inference {threshold = prior}

--- a/spm_dcm_fmri_mar.m
+++ b/spm_dcm_fmri_mar.m
@@ -154,7 +154,11 @@ DCM.M.N  = 32;
 Y            = DCM.Y;
 Y.y          = Y.mar;
 Y.Q          = speye(length(Y.y(:)));
-[Ep,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.U,Y);
+[Ep,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.U,Y);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Bayesian inference {threshold = prior}

--- a/spm_dcm_fmri_nmm.m
+++ b/spm_dcm_fmri_nmm.m
@@ -200,7 +200,11 @@ M.ns = v;
     
 % nonlinear system identification (Variational Laplace)
 %==========================================================================
-[Ep,Cp,Eh,F] = spm_nlsi_GN(M,U,Y);
+[Ep,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(M,U,Y);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
  
 % predicted responses (y) and residuals (R)
 %--------------------------------------------------------------------------

--- a/spm_nlsi_GN.m
+++ b/spm_nlsi_GN.m
@@ -1,6 +1,6 @@
-function [Ep,Cp,Eh,F,L,dFdp,dFdpp] = spm_nlsi_GN(M,U,Y)
+function [Ep,Cp,Eh,F,L,dFdp,dFdpp,converged,Fhist] = spm_nlsi_GN(M,U,Y)
 % Bayesian inversion of nonlinear models - Gauss-Newton/Variational Laplace
-% FORMAT [Ep,Cp,Eh,F,L,dFdp,dFdpp] = spm_nlsi_GN(M,U,Y)
+% FORMAT [Ep,Cp,Eh,F,L,dFdp,dFdpp,converged,Fhist] = spm_nlsi_GN(M,U,Y)
 %
 % [Dynamic] MIMO models
 %__________________________________________________________________________
@@ -49,6 +49,17 @@ function [Ep,Cp,Eh,F,L,dFdp,dFdpp] = spm_nlsi_GN(M,U,Y)
 % log evidence
 %--------------------------------------------------------------------------
 % F   - [-ve] free energy F = log evidence = p(y|f,g,pE,pC) = p(y|m)
+%
+% convergence diagnostics
+%--------------------------------------------------------------------------
+% converged - logical scalar; true iff the convergence criterion was met
+%             before M.Nmax iterations (i.e. the inner loop broke out
+%             rather than running to completion)
+% Fhist     - struct recording the accepted free energy trajectory:
+%               .F  (1 x k)         accepted F at each iteration
+%               .L  (3 x k)         accepted log-evidence components at
+%                                   each iteration
+%             where k is the number of iterations actually performed
 %
 %__________________________________________________________________________
 % Returns the moments of the posterior p.d.f. of the parameters of a
@@ -328,6 +339,7 @@ C.F   = -Inf;                                   % free energy
 v     = -4;                                     % log ascent rate
 dFdh  = zeros(nh,1);
 dFdhh = zeros(nh,nh);
+Fhist = struct('F', [], 'L', []);
 for k = 1:M.Nmax
     
     % time
@@ -626,6 +638,15 @@ for k = 1:M.Nmax
         
     end
     
+    % record per-iteration accepted state
+    %----------------------------------------------------------------------
+    Fhist.F = [Fhist.F, C.F];
+    if isempty(Fhist.L)
+        Fhist.L = C.L(:);
+    else
+        Fhist.L(:,end+1) = C.L(:);
+    end
+
     % convergence
     %----------------------------------------------------------------------
     dF  = dFdp'*dp;
@@ -653,3 +674,4 @@ Cp     = V*C.Cp(ip,ip)*V';
 Eh     = C.h;
 F      = C.F;
 L      = C.L;
+converged = all(criterion);

--- a/spm_nlsi_N.m
+++ b/spm_nlsi_N.m
@@ -1,6 +1,6 @@
-function [Ep,Eg,Cp,Cg,S,F,L] = spm_nlsi_N(M,U,Y)
+function [Ep,Eg,Cp,Cg,S,F,L,converged,Fhist] = spm_nlsi_N(M,U,Y)
 % Bayesian inversion of a linear-nonlinear model of the form F(p)*G(g)'
-% FORMAT [Ep,Eg,Cp,Cg,S,F,L]= spm_nlsi_N(M,U,Y)
+% FORMAT [Ep,Eg,Cp,Cg,S,F,L,converged,Fhist]= spm_nlsi_N(M,U,Y)
 %
 % Generative model
 %__________________________________________________________________________
@@ -65,6 +65,17 @@ function [Ep,Eg,Cp,Cg,S,F,L] = spm_nlsi_N(M,U,Y)
 %     L(7) = - nq*spm_logdet(S)/2;      precision
 %     L(8) = spm_logdet(ibC*Cb)/2;      parameter complexity
 %     L(9) = spm_logdet(ihC*Ch)/2;      precision complexity
+%
+% convergence diagnostics
+%--------------------------------------------------------------------------
+% converged - logical scalar; true iff the convergence criterion was met
+%             before M.Nmax iterations (i.e. the inner loop broke out
+%             rather than running to completion)
+% Fhist     - struct recording the accepted free energy trajectory:
+%               .F  (1 x k)         accepted F at each iteration
+%               .L  (9 x k)         accepted log-evidence components at
+%                                   each iteration
+%             where k is the number of iterations actually performed
 %
 %__________________________________________________________________________
 % Returns the moments of the posterior p.d.f. of the parameters of a
@@ -317,8 +328,9 @@ dgdp  = zeros(ny,np);
 dgdg  = zeros(ny,ng);
 dFdh  = zeros(nh,1);
 dFdhh = zeros(nh,nh);
+Fhist = struct('F', [], 'L', []);
 
- 
+
 % Optimize p: parameters of f(x,u,p)
 %==========================================================================
 EP     = [];
@@ -597,6 +609,15 @@ for ip = 1:M.Nmax
         
     end
  
+    % record per-iteration accepted state
+    %----------------------------------------------------------------------
+    Fhist.F = [Fhist.F, C.F];
+    if isempty(Fhist.L)
+        Fhist.L = C.L(:);
+    else
+        Fhist.L(:,end+1) = C.L(:);
+    end
+
     % convergence
     %----------------------------------------------------------------------
     dF  = dFdp'*dp;
@@ -618,6 +639,7 @@ Cp     = Vp*C.Cb((1:np),     (1:np)     )*Vp';
 Cg     = Vg*C.Cb((1:ng) + np,(1:ng) + np)*Vg';
 F      = C.F;
 L      = C.L;
+converged = all(criterion);
 warning(sw);
 
 % diagnostic

--- a/toolbox/dcm_meeg/spm_dcm_csd.m
+++ b/toolbox/dcm_meeg/spm_dcm_csd.m
@@ -176,7 +176,11 @@ DCM.xY.X0 = sparse(size(DCM.xY.Q,1),0);
 
 % Variational Laplace: model inversion
 %==========================================================================
-[Qp,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+[Qp,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Data ID

--- a/toolbox/dcm_meeg/spm_dcm_dem.m
+++ b/toolbox/dcm_meeg/spm_dcm_dem.m
@@ -139,7 +139,11 @@ Nm    = size(M.U,2);
 
 % EM: inversion
 %==========================================================================
-[Qp,Qg,Cp,Cg,Ce,F] = spm_nlsi_N(M,xU,xY);
+[Qp,Qg,Cp,Cg,Ce,F,~,converged,Fhist] = spm_nlsi_N(M,xU,xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 % Data ID
 %==========================================================================

--- a/toolbox/dcm_meeg/spm_dcm_erp.m
+++ b/toolbox/dcm_meeg/spm_dcm_erp.m
@@ -246,7 +246,11 @@ M.x    = spm_dcm_neural_x(pE,M);
 
 % EM: inversion
 %==========================================================================
-[Qp,Qg,Cp,Cg,Ce,F,LE] = spm_nlsi_N(M,xU,xY);
+[Qp,Qg,Cp,Cg,Ce,F,LE,converged,Fhist] = spm_nlsi_N(M,xU,xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Data ID

--- a/toolbox/dcm_meeg/spm_dcm_ind.m
+++ b/toolbox/dcm_meeg/spm_dcm_ind.m
@@ -149,7 +149,11 @@ M.dur = dur;
  
 % EM: inversion
 %--------------------------------------------------------------------------
-[Qp,Qg,Cp,Cg,Ce,F] = spm_nlsi_N(M,xU,xY);
+[Qp,Qg,Cp,Cg,Ce,F,~,converged,Fhist] = spm_nlsi_N(M,xU,xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
  
  
 % Data ID

--- a/toolbox/dcm_meeg/spm_dcm_nfm.m
+++ b/toolbox/dcm_meeg/spm_dcm_nfm.m
@@ -105,8 +105,12 @@ DCM.M.U   = DCM.M.U/scale;
  
 % Model inversion
 %--------------------------------------------------------------------------
-[Qp,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+[Qp,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
 Ce           = exp(-Eh);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
  
 % Data ID
 %==========================================================================

--- a/toolbox/dcm_meeg/spm_dcm_phase.m
+++ b/toolbox/dcm_meeg/spm_dcm_phase.m
@@ -148,7 +148,11 @@ end
 
 % EM: inversion
 %--------------------------------------------------------------------------
-[Qp,Qg,Cp,Cg,Ce,F] = spm_nlsi_N(M,xU,xY);
+[Qp,Qg,Cp,Cg,Ce,F,~,converged,Fhist] = spm_nlsi_N(M,xU,xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Data ID

--- a/toolbox/dcm_meeg/spm_dcm_ssr.m
+++ b/toolbox/dcm_meeg/spm_dcm_ssr.m
@@ -118,8 +118,12 @@ DCM.M.U   = U*sqrt(norm(spm_vec(DCM.xY.y),Inf)/norm(spm_vec(Hc),Inf));
 
 % EM: inversion
 %--------------------------------------------------------------------------
-[Qp,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+[Qp,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
 Ce           = exp(-Eh);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 % Data ID
 %==========================================================================

--- a/toolbox/dcm_meeg/spm_dcm_tfm.m
+++ b/toolbox/dcm_meeg/spm_dcm_tfm.m
@@ -206,8 +206,12 @@ end
 % Variational Laplace: model inversion
 %==========================================================================
 DCM.M.Nmax   = 32;
-[Qp,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+[Qp,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
 DCM.M.ds     = 1;
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
 
 
 % Re-estimate spatial (lead field) parameters for ERP

--- a/toolbox/dcm_meeg/spm_dcm_tfm_multimodal.m
+++ b/toolbox/dcm_meeg/spm_dcm_tfm_multimodal.m
@@ -217,7 +217,11 @@ end
 % Variational Laplace: model inversion
 %==========================================================================
 DCM.M.Nmax   = 32;
-[Qp,Cp,Eh,F] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+[Qp,Cp,Eh,F,~,~,~,converged,Fhist] = spm_nlsi_GN(DCM.M,DCM.xU,DCM.xY);
+
+DCM.convergence.converged = converged;
+DCM.convergence.F         = Fhist.F;
+DCM.convergence.L         = Fhist.L;
  
  
 % Data ID


### PR DESCRIPTION
Closes: https://github.com/spm/spm/issues/131.

Fitted DCM structs currently carry no record of whether the optimizer converged within its iteration budget (64 for `spm_nlsi_N` / ERP, 128 for `spm_nlsi_GN` / CSD, fMRI). This adds a lightweight record of provenance: a `converged` bool plus the per-iteration trajectory of the free-energy log-evidence components.

### Optimizer changes (backward compatible)

Two new trailing outputs on each estimator, existing callers that capture fewer outputs are unaffected.

- `spm_nlsi_N(M,U,Y) → [Ep,Eg,Cp,Cg,S,F,L,converged,Fhist]`
- `spm_nlsi_GN(M,U,Y) → [Ep,Cp,Eh,F,L,dFdp,dFdpp,converged,Fhist]`

Where:

- `converged`, logical; `true` iff `all(criterion)` was satisfied before `M.Nmax`, i.e. the inner loop broke out rather than running to completion.
- `Fhist.F`, `1 × k` row of the accepted `C.F` at each iteration `k` actually performed.
- `Fhist.L`, `nL × k` matrix of the accepted log-evidence components (`C.L`) at each iteration. `nL` is 9 in `spm_nlsi_N` and 3 in `spm_nlsi_GN`.

Recording happens at the end of each iteration *after* the accept/reject step and *before* the convergence check, so it captures the iteration on which the loop breaks. Because only accepted updates are recorded, `Fhist.F` is monotonically non-decreasing, plateaus indicate rejected proposals.

### DCM-level wiring

All DCM estimators that call into the optimizers above now capture the new outputs and surface them on the returned struct as `DCM.convergence.{converged, F, L}`:

- `spm_dcm_estimate`
- `spm_dcm_fmri_csd`, `spm_dcm_fmri_mar`, `spm_dcm_fmri_nmm`
- `toolbox/dcm_meeg/spm_dcm_erp`, `spm_dcm_csd`, `spm_dcm_ssr`, `spm_dcm_phase`, `spm_dcm_ind`, `spm_dcm_dem`, `spm_dcm_nfm`, `spm_dcm_tfm`, `spm_dcm_tfm_multimodal`

### Out of scope / future work

- Non-DCM callers of the same optimizers (`spm_ness_*`, `spm_sparse_regression`, `spm_eeg_inv_vbecd*`, `spm_fp_fmin`, DEM demos) are intentionally left unchanged — they keep working through the backward-compatible signature extension.
- `spm_dcm_fmri_csd_DEM.m` has its `spm_nlsi_GN` call commented out, so no edit was needed.

### Testing

Tested with the following scripts:
```
% Demonstration of the new convergence-reporting outputs
%
% Both spm_nlsi_N and spm_nlsi_GN now return two additional trailing
% outputs, and all DCM-level estimators (spm_dcm_{erp,csd,ssr,...},
% spm_dcm_fmri_{csd,mar,nmm}, spm_dcm_estimate) surface them on the
% returned struct as DCM.convergence.{converged, F, L}.
%
% This script exercises the change by fitting a tiny synthetic linear
% regression with spm_nlsi_GN directly, reporting the new fields, and
% plotting the per-iteration trajectory of the free-energy components.

% ----- path setup --------------------------------------------------------
spm_path = fullfile(getenv('HOME'), 'packages', 'spm');
if ~contains(path, spm_path)
    addpath(spm_path);
end

% ----- synthetic problem -------------------------------------------------
% y = X*P + noise; recover P from y.
rng(0);
n = 32;       % observations
m = 2;        % parameters
X = randn(n, m);
P_true = [1.5; -0.7];

Y.y = X * P_true + 0.1 * randn(n, 1);
Y.Q = speye(n);

% generative model: linear in parameters, no inputs
M.IS      = @(P, M, U) X * P;
M.pE      = zeros(m, 1);
M.pC      = eye(m);
M.Nmax    = 32;
M.noprint = 0;

U = [];

% ----- run the optimizer -------------------------------------------------
[Ep, Cp, Eh, F, L, dFdp, dFdpp, converged, Fhist] = spm_nlsi_GN(M, U, Y);

% ----- report ------------------------------------------------------------
fprintf('\n=== Convergence Report ===\n');
fprintf('  converged within Nmax=%d: %s\n', M.Nmax, mat2str(logical(converged)));
fprintf('  iterations actually run: %d\n',   numel(Fhist.F));
fprintf('  final free energy F:     %.4f\n', F);
fprintf('  true P:      [%6.3f, %6.3f]\n', P_true(1), P_true(2));
fprintf('  estimated P: [%6.3f, %6.3f]\n', Ep(1), Ep(2));

% emulate the DCM.convergence struct that DCM-level estimators now populate
DCM.convergence.converged = converged;
DCM.convergence.F         = Fhist.F;
DCM.convergence.L         = Fhist.L;

fprintf('\nDCM.convergence (what spm_dcm_* now stores):\n');
disp(DCM.convergence)
fprintf('  size(DCM.convergence.F) = [%d %d]\n', size(DCM.convergence.F));
fprintf('  size(DCM.convergence.L) = [%d %d]\n', size(DCM.convergence.L));

% ----- plot trajectories -------------------------------------------------
figure('Name', 'DCM convergence reporting demo');

subplot(2, 1, 1);
plot(Fhist.F, '-o', 'LineWidth', 1.5);
title('Accepted free energy F per iteration');
xlabel('iteration'); ylabel('F'); grid on;

subplot(2, 1, 2);
plot(Fhist.L', '-o', 'LineWidth', 1.5);
legend({'L(1) accuracy', ...
        'L(2) parameter complexity', ...
        'L(3) precision complexity'}, 'Location', 'best');
title('Log-evidence components L per iteration (3 for spm\_nlsi\_GN)');
xlabel('iteration'); ylabel('L_i'); grid on;
```
and
```
% Demo: convergence reporting on a real DCM-CSD fit.
%
% Uses the LFP demo from
%   https://github.com/pranaysy/DCM_CSD_Demo
% Clones the repo (if not already present), loads one of the pre-built DCM
% structs, refits it with spm_dcm_csd (which now records convergence
% statistics via the modified spm_nlsi_GN), and plots the per-iteration
% trajectory of the free-energy components.

% ----- paths -------------------------------------------------------------
spm_path  = fullfile(getenv('HOME'), 'packages', 'spm');
demo_root = fullfile(fileparts(mfilename('fullpath')), 'DCM_CSD_Demo');
demo_url  = 'https://github.com/pranaysy/DCM_CSD_Demo.git';

if ~contains(path, spm_path)
    addpath(spm_path);
end
% spm('Defaults','EEG') adds the toolbox subtrees (incl. dcm_meeg)
% needed for spm_dcm_csd; safe to call repeatedly.
spm('Defaults', 'EEG');

% ----- fetch the demo repo if missing ------------------------------------
if ~isfolder(demo_root)
    fprintf('Cloning DCM_CSD_Demo into %s ...\n', demo_root);
    [status, output] = system(sprintf('git clone --depth 1 %s "%s"', ...
                                      demo_url, demo_root));
    if status ~= 0
        error('git clone failed:\n%s', output);
    end
end

% ----- load one of the pre-built DCMs ------------------------------------
% DCM_NoB.mat is the smaller candidate (no condition-specific B effects).
% Switch to DCM_Full.mat to exercise the Full model instead.
dcm_file = fullfile(demo_root, 'models', 'DCM_NoB.mat');
fprintf('Loading %s ...\n', dcm_file);
S = load(dcm_file);
DCM = S.DCM;

% the .mat was saved on a different machine, so fix the embedded paths
data_mat     = fullfile(demo_root, 'data', 'LFP_demo_data.mat');
DCM.xY.Dfile = data_mat;
DCM.name     = fullfile(fileparts(mfilename('fullpath')), 'DCM_NoB_refit.mat');

% ----- refit -------------------------------------------------------------
fprintf('Refitting with spm_dcm_csd (this takes a few minutes) ...\n');
tStart = tic;
DCM = spm_dcm_csd(DCM);
fprintf('Refit completed in %.1f s.\n', toc(tStart));

% ----- report ------------------------------------------------------------
if ~isfield(DCM, 'convergence')
    error(['DCM.convergence is missing -- you are likely running an old ' ...
           'SPM without the feature/dcm-convergence-reporting branch.']);
end

% spm_nlsi_GN defaults M.Nmax to 128 internally if unset; reflect that here
if isfield(DCM.M, 'Nmax'), Nmax = DCM.M.Nmax; else, Nmax = 128; end

fprintf('\n=== Convergence Report ===\n');
fprintf('  converged within Nmax=%d: %s\n', ...
        Nmax, mat2str(logical(DCM.convergence.converged)));
fprintf('  iterations actually run: %d\n', numel(DCM.convergence.F));
fprintf('  final free energy F:     %.4f\n', DCM.convergence.F(end));
fprintf('  size(DCM.convergence.L): [%d %d]\n', size(DCM.convergence.L));

% ----- plot trajectories -------------------------------------------------
figure('Name', 'DCM-CSD convergence (DCM_NoB)');

subplot(2, 1, 1);
plot(DCM.convergence.F, '-o', 'LineWidth', 1.5);
title('Accepted free energy F per iteration');
xlabel('iteration'); ylabel('F'); grid on;

subplot(2, 1, 2);
plot(DCM.convergence.L', '-o', 'LineWidth', 1.5);
legend({'L(1) accuracy', ...
        'L(2) parameter complexity', ...
        'L(3) precision complexity'}, 'Location', 'best');
title('Log-evidence components L per iteration');
xlabel('iteration'); ylabel('L_i'); grid on;
```
