### PR TITLE
Change default printing format to PDF

### DIFF
--- a/spm_defaults.m
+++ b/spm_defaults.m
@@ -36,7 +36,7 @@ defaults.cmdline  = 0;
 defaults.ui.monitor = NaN;
 defaults.ui.colour  = [0.58 0.77 0.57];
 defaults.ui.fs      = 14;  % unused
-defaults.ui.print   = 'ps';
+defaults.ui.print   = 'pdf';
 defaults.renderer   = 'opengl';
 
 % File format specific


### PR DESCRIPTION
On R2025b (`MATLAB Version: 25.2.0.3150157 (R2025b) Update 4`) and MacOS I get a error during Realign when the motion plots are to be printed: `Illegal device option 'psc2' specified.`  Full context here:

```
------------------------------------------------------------------------
27-May-2026 15:35:33 - Running 'Realign: Estimate & Reslice'

SPM25: spm_realign                                 15:35:33 - 27/05/2026
========================================================================
Print error: nothing has been printed.
Error using matlab.graphics.internal.mlprintjob/getOutputDevice
Illegal device option 'psc2' specified.
Completed                               :          15:36:25 - 27/05/2026
```

The fix is to change the defaults from `ps` to `pdf`. It's been tested on Realign but no other calls to `spm_print`.

---
I have read the CLA Document and I hereby sign the CLA
---
