### PR TITLE
Fix pat-cross-repo in install_test_standalone.yml

### DIFF
--- a/.github/workflows/install_test_standalone.yml
+++ b/.github/workflows/install_test_standalone.yml
@@ -36,12 +36,21 @@ jobs:
     env:
       cache-key: tests-data2
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-tests-data
+          permission-contents: read
       - name: Get latest commit for tests data
         id: checkout-tests-data
         uses: actions/checkout@v4
         with:
           repository: spm/spm-tests-data
-          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: tests/data
           fetch-depth: 1
           lfs: false


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

### 🔴 `pat-cross-repo` · `download_test_data`

Job `download_test_data`, step `Get latest commit for tests data` uses `actions/checkout@v4` with `secrets.TESTS_DATA_REPO_TOKEN` and the comprehension marks a high-confidence cross-repo checkout target (`spm/spm-tests-data`). This is a PAT-authenticated cross-repository access…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/install_test_standalone.yml
+++ b/.github/workflows/install_test_standalone.yml
@@ -36,12 +36,21 @@
     env:
       cache-key: tests-data2
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-tests-data
+          permission-contents: read
       - name: Get latest commit for tests data
         id: checkout-tests-data
         uses: actions/checkout@v4
         with:
           repository: spm/spm-tests-data
-          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: tests/data
           fetch-depth: 1
           lfs: false
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
