### PR TITLE
Fix pat-cross-repo in matlab.yml

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -73,13 +73,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-tests-data
+          permission-contents: read
       - name: Get latest commit for tests data  # shallow fetch to get revision
         id: checkout-tests-data
         if: ${{ needs.configure.outputs.is-pr == 'false' }}
         uses: actions/checkout@v4
         with:
           repository: spm/spm-tests-data
-          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: tests/data
           fetch-depth: 1
           lfs: false


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

### 🔴 `pat-cross-repo` · `matlab-tests`

Job `matlab-tests`, step `Get latest commit for tests data` uses `secrets.TESTS_DATA_REPO_TOKEN` as a PAT to check out `spm/spm-tests-data` with high-confidence cross-repo signals. This is a cross-repository credential boundary and should be treated as a privileged secret use in…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -73,13 +73,22 @@
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-tests-data
+          permission-contents: read
       - name: Get latest commit for tests data  # shallow fetch to get revision
         id: checkout-tests-data
         if: ${{ needs.configure.outputs.is-pr == 'false' }}
         uses: actions/checkout@v4
         with:
           repository: spm/spm-tests-data
-          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: tests/data
           fetch-depth: 1
           lfs: false
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
