### PR TITLE
Fix pat-cross-repo in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,11 +284,21 @@ jobs:
           echo "SPM_RELEASE=${tag:0:5}" >> $GITHUB_ENV
           echo "SPM_REVISION=${tag:6}" >> $GITHUB_ENV
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-docker
+          permission-actions: write
+          permission-contents: write
       - name: Trigger workflow in spm-docker
         if: env.PRERELEASE == 'false' && runner.os == 'Linux' && matrix.version == 'latest' && github.event_name != 'workflow_dispatch'
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PAT_TOKEN_SPM_DOCKER }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: spm/spm-docker
           event-type: trigger-container-build
           client-payload: |-


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

### 🔴 `pat-cross-repo` · `build_matlab_standalone`

In job `build_matlab_standalone`, the step `Trigger workflow in spm-docker` uses `secrets.PAT_TOKEN_SPM_DOCKER` with `peter-evans/repository-dispatch@v3` and has high-confidence cross-repo signals for `repository_dispatch:spm/spm-docker`. This is a cross-repository PAT usage, so…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,11 +284,21 @@
           echo "SPM_RELEASE=${tag:0:5}" >> $GITHUB_ENV
           echo "SPM_REVISION=${tag:6}" >> $GITHUB_ENV
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spm-docker
+          permission-actions: write
+          permission-contents: write
       - name: Trigger workflow in spm-docker
         if: env.PRERELEASE == 'false' && runner.os == 'Linux' && matrix.version == 'latest' && github.event_name != 'workflow_dispatch'
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PAT_TOKEN_SPM_DOCKER }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: spm/spm-docker
           event-type: trigger-container-build
           client-payload: |-
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
