### PR TITLE
Test: run the unit test suite inside the official container

### DIFF
--- a/.github/workflows/test_container.yml
+++ b/.github/workflows/test_container.yml
@@ -1,0 +1,284 @@
+
+# Runs the SPM unit test suite inside the official container.
+#
+# Why this exists rather than just install_test_standalone.yml: a GitHub runner
+# and a container are not the same environment. The suite passes on a plain
+# ubuntu runner while some tests hang in the container, typically because they
+# reach for graphics that a headless container cannot provide.
+#
+# Why it lives here rather than in spm/spm-docker: the unit tests are compiled
+# and encrypted into the CTF archive, so a change to tests/*.m only takes effect
+# once the standalone is recompiled. spm-docker builds its images from published
+# release assets and therefore cannot test unreleased code. Compiling needs the
+# MATLAB Compiler licence, which is configured in this repository.
+#
+# The container recipe itself is NOT duplicated here. It is checked out from
+# spm-docker so that this workflow and the published images cannot drift apart:
+# a failure here means something real about the shipped container.
+#
+# Two ways to use it:
+#   - workflow_dispatch on your own branch, to see a test fail before your fix
+#     and pass after it
+#   - the weekly schedule, to catch regressions on main
+
+name: Test SPM in Container
+
+on:
+  schedule:
+    # 03:00 UTC every Monday
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      test:
+        description: 'Single test file to run, e.g. test_spm_plot_ci (empty = whole suite)'
+        required: false
+        type: string
+      timeout_per_test:
+        description: 'Seconds before a hanging test container is killed'
+        required: false
+        default: '300'
+        type: string
+      spm_docker_repo:
+        description: 'Repository to take the container recipe from (use a fork to try changes before they are merged)'
+        required: false
+        default: spm/spm-docker
+        type: string
+      spm_docker_ref:
+        description: 'Branch or tag of that repository'
+        required: false
+        default: main
+        type: string
+
+env:
+  MLM_LICENSE_TOKEN: ${{ secrets.MATLAB_BATCH_TOKEN }}
+
+permissions:
+  contents: read
+
+jobs:
+  build_standalone:
+    name: Build Standalone (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout SPM
+        uses: actions/checkout@v4
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: latest
+          products: |
+            MATLAB_Compiler
+            Signal_Processing_Toolbox
+
+      - name: Extract MATLAB version to file
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            fileID = fopen('matlab_release.txt', 'w');
+            fprintf(fileID, matlabRelease.Release);
+            fclose(fileID);
+        timeout-minutes: 5
+
+      - name: Set environment variable with MATLAB version
+        shell: bash
+        run: echo "MATLAB_VERSION=$(cat matlab_release.txt)" >> $GITHUB_ENV
+
+      - name: Build MATLAB standalone
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            addpath(genpath('.'));
+            savepath;
+            spm_make_standalone
+            mkdir('runtime_installer');
+            if ~isMATLABReleaseOlderThan("R2024b")
+              compiler.runtime.customInstaller('Runtime_${{ env.MATLAB_VERSION }}_for_spm_standalone', '../standalone/requiredMCRProducts.txt', OutputDir='../runtime_installer');
+            end
+
+      # Same layout as a release asset, which is what Dockerfile.local expects
+      - name: Compress standalone
+        shell: bash
+        run: |
+          cd ..
+          mv standalone spm_standalone
+          zip -r spm_standalone_Linux.zip spm_standalone runtime_installer
+          mv spm_standalone_Linux.zip spm/
+          unzip -l spm/spm_standalone_Linux.zip | head -20
+
+      - name: Upload standalone artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spm-standalone-Linux
+          path: spm_standalone_Linux.zip
+          retention-days: 7
+
+  test_container:
+    name: Test in Container
+    needs: build_standalone
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      # Deliberately no checkout of SPM here. The tests that run are the ones
+      # compiled into the standalone, not the ones in the source tree, and
+      # having a tests/ directory lying around invites exactly that confusion.
+
+      # The container recipe and the test runner are maintained in spm-docker.
+      # Taking them from there rather than reimplementing them is the whole
+      # point: it keeps this workflow honest about the shipped image.
+      #
+      # spm-docker is public, so the default GITHUB_TOKEN is enough to check it
+      # out. The repository is an input so that changes to the recipe can be
+      # tried from a fork before they are merged.
+      - name: Checkout container recipe from spm-docker
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.spm_docker_repo || 'spm/spm-docker' }}
+          ref: ${{ inputs.spm_docker_ref || 'main' }}
+          path: spm-docker
+
+      # Fail here with a clear message rather than deep inside `docker build`.
+      - name: Verify the container recipe is present
+        run: |
+          MISSING=""
+          for f in matlab/Dockerfile.local matlab/run_tests.sh; do
+            [ -f "spm-docker/$f" ] || MISSING="$MISSING $f"
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::${{ inputs.spm_docker_repo || 'spm/spm-docker' }}@${{ inputs.spm_docker_ref || 'main' }} is missing:${MISSING}. These arrive with the container-testing PR in spm-docker; until it is merged, point spm_docker_repo/spm_docker_ref at the branch that has them."
+            exit 1
+          fi
+
+      - name: Download standalone artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spm-standalone-Linux
+          path: spm-docker
+
+      - name: Check whether test data is reachable
+        id: data_access
+        env:
+          TESTS_DATA_REPO_TOKEN: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+        run: |
+          if [ -n "$TESTS_DATA_REPO_TOKEN" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "available=false" >> $GITHUB_OUTPUT
+          if [ "${{ github.repository_owner }}" = "spm" ]; then
+            echo "::error::TESTS_DATA_REPO_TOKEN is not set, so the suite would run with reduced coverage."
+            exit 1
+          fi
+          echo "::warning::TESTS_DATA_REPO_TOKEN is not set (expected on a fork); data-dependent tests will be Incomplete."
+
+      - name: Checkout test data
+        if: steps.data_access.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: spm/spm-tests-data
+          token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
+          path: tests/data
+          lfs: true
+
+      - name: Verify test data
+        if: steps.data_access.outputs.available == 'true'
+        run: |
+          SIZE_KB=$(du -sk tests/data 2>/dev/null | cut -f1)
+          echo "tests/data is ${SIZE_KB} KB"
+          if [ "${SIZE_KB:-0}" -lt 51200 ]; then
+            echo "::error::tests/data is only ${SIZE_KB} KB; the Git LFS checkout did not resolve."
+            exit 1
+          fi
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h /
+
+      - name: Build container around the freshly built standalone
+        timeout-minutes: 45
+        working-directory: spm-docker
+        run: |
+          docker build -t spm-local -f matlab/Dockerfile.local .
+          docker run --rm spm-local --version
+
+      # Skipped when a single test was requested: there is nothing to gain from
+      # running the whole suite first if you already know which test you are
+      # iterating on.
+      - name: Unit tests (whole suite, single session)
+        id: tests_fast
+        # Not `inputs.test == ''`: on a schedule event inputs.test is null, and
+        # relying on null-to-empty-string coercion here is needless risk.
+        if: ${{ !inputs.test }}
+        continue-on-error: true
+        timeout-minutes: 30
+        working-directory: spm-docker
+        run: |
+          MOUNT=""
+          if [ -d "${{ github.workspace }}/tests/data" ]; then
+            TESTS_DIR=$(docker run --rm --entrypoint sh spm-local -c 'ls -d /opt/spm/spm*_mcr/spm*/tests' | tr -d '\r')
+            MOUNT="-v ${{ github.workspace }}/tests/data:${TESTS_DIR}/data"
+          fi
+          trap 'docker stop spm_tests_all >/dev/null 2>&1 || true' EXIT
+          set -o pipefail
+          docker run --rm --name spm_tests_all $MOUNT spm-local test \
+            | tee "${{ github.workspace }}/suite.log"
+
+      # Runs when the fast phase found a problem, or when a specific test was
+      # asked for. This is the phase that names the culprit.
+      - name: Unit tests (isolated per test file)
+        id: tests_isolated
+        if: ${{ inputs.test || steps.tests_fast.outcome == 'failure' }}
+        continue-on-error: true
+        timeout-minutes: 90
+        working-directory: spm-docker
+        env:
+          SUMMARY_FILE: ${{ github.workspace }}/test_summary.md
+          ONLY_TESTS: ${{ inputs.test }}
+        run: |
+          if [ -d "${{ github.workspace }}/tests/data" ]; then
+            export SPM_TESTS_DATA="${{ github.workspace }}/tests/data"
+          fi
+          bash matlab/run_tests.sh spm-local "" "${{ inputs.timeout_per_test || '300' }}"
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## SPM unit tests in container"
+            echo ""
+            echo "Ref: \`${{ github.ref_name }}\` at \`${{ github.sha }}\`"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+          if [ -f test_summary.md ]; then
+            cat test_summary.md >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.tests_fast.outcome }}" = "success" ]; then
+            echo "Whole suite passed in a single Runtime session." >> $GITHUB_STEP_SUMMARY
+          fi
+          exit 0
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-test-logs
+          path: |
+            spm-docker/spm_test_results_*.log
+            test_summary.md
+            suite.log
+          if-no-files-found: ignore
+          retention-days: 90
+
+      # Either phase can fail the run: the fast phase because that is the command
+      # users actually run, the isolated phase because it is the only one that
+      # runs when a specific test was requested.
+      - name: Fail if tests did not pass
+        if: steps.tests_fast.outcome == 'failure' || steps.tests_isolated.outcome == 'failure'
+        run: |
+          echo "::error::The SPM unit suite does not pass inside the container. A TIMEOUT usually means the test reached for graphics, which blocks in a headless container."
+          if [ "${{ steps.tests_fast.outcome }}" = "failure" ] && \
+             [ "${{ steps.tests_isolated.outcome }}" = "success" ]; then
+            echo "::warning::Every test passes in isolation, so the failure is an interaction between tests in a shared session."
+          fi
+          exit 1


### PR DESCRIPTION
A GitHub runner and a container are not the same environment: the suite passes on a plain ubuntu runner while some tests hang in the container, typically because they reach for graphics that a headless container cannot provide. Nothing in CI covered that.

This lives here rather than in spm-docker because the unit tests are compiled and encrypted into the CTF archive, so a change to tests/*.m only takes effect once the standalone is recompiled. spm-docker builds its images from published release assets and cannot test unreleased code. Compiling needs the MATLAB Compiler licence, which is configured in this repository.

The container recipe is not duplicated here. It is checked out from spm-docker so the two cannot drift apart, which is what makes a failure here say something about the shipped image. The repository and ref are inputs so a change to the recipe can be tried from a fork before it is merged.

Runs weekly on main, and on demand against any branch. The test input restricts a run to a single test file, which is how a fix for a failing test is demonstrated: red before, green after. Without it the whole suite runs in one session first, falling back to one container per test file only when that fails, so a hang is attributed to a named test.