### PR TITLE
Maintenance: collapse the test matrix to a quick and a full tier

### DIFF
--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -24,13 +24,14 @@ jobs:
             mex_ext: mexa64
             matlab_release: R2020a
             matlab_legacy: true
-          # On Mac and Windows, only the Matlab version matters for mex compatibility, so the OS can be the latest.  
+          # On Mac and Windows, mostly the Matlab version matters for mex compatibility,
+          # but macos-latest is out: Xcode 26 breaks C++ MEX linking for R2023b.
           - os: macos-15-intel
             os_name: macOS_Intel
             mex_ext: mexmaci64
             matlab_release: R2020a
             matlab_legacy: true
-          - os: macos-latest
+          - os: macos-15
             os_name: macOS_Apple_Silicon
             mex_ext: mexmaca64
             matlab_release: R2023b

--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -24,8 +24,8 @@ jobs:
             mex_ext: mexa64
             matlab_release: R2020a
             matlab_legacy: true
-          # On Mac and Windows, mostly the Matlab version matters for mex compatibility,
-          # but macos-latest is out: Xcode 26 breaks C++ MEX linking for R2023b.
+          # On Mac and Windows the Matlab version drives mex compatibility, but macos-latest
+          # is avoided because its Xcode 26 linker cannot link C++ MEX files for R2023b.
           - os: macos-15-intel
             os_name: macOS_Intel
             mex_ext: mexmaci64

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -21,16 +21,26 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
-          # extra-os adds macos-26 (Apple Silicon) coverage for the releases that
-          # build there. Empty on PRs so they keep the reduced matrix.
+          # The reduced sweep is oldest-supported plus newest, which catches almost
+          # every regression within a day; the full sweep runs on the weekly cron,
+          # on releases and on manual dispatch. extra-os adds macos-26 (Apple
+          # Silicon) coverage for the releases that build there, and is empty on
+          # PRs so they keep the reduced matrix.
+          FULL='["R2020a","R2020b","R2021a","R2021b","R2022a","R2022b","R2023a","R2023b","R2024a","R2024b","R2025a","R2025b", "latest"]'
+          REDUCED='["R2020a","latest"]'
           if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "is-pr=true" >> $GITHUB_OUTPUT
-            echo 'versions=["R2020a","latest"]' >> $GITHUB_OUTPUT
+            echo "versions=$REDUCED" >> $GITHUB_OUTPUT
             echo 'extra-os=[]' >> $GITHUB_OUTPUT
+          elif [ "$EVENT_SCHEDULE" = "15 3 * * *" ]; then
+            echo "is-pr=false" >> $GITHUB_OUTPUT
+            echo "versions=$REDUCED" >> $GITHUB_OUTPUT
+            echo 'extra-os=[{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           else
             echo "is-pr=false" >> $GITHUB_OUTPUT
-            echo 'versions=["R2020a","R2020b","R2021a","R2021b","R2022a","R2022b","R2023a","R2023b","R2024a","R2024b","R2025a","R2025b", "latest"]' >> $GITHUB_OUTPUT
+            echo "versions=$FULL" >> $GITHUB_OUTPUT
             echo 'extra-os=[{"os":"macos-latest","version":"R2025b"},{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           fi
 
@@ -148,26 +158,37 @@ jobs:
         with:
           release: ${{matrix.version}}
 
-      - name: Run regression tests with existing MEX files (legacy)
-        if: ${{github.event.schedule == '40 16 * * 3' && (matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b')}}
+      - name: Select test classes
+        id: classes
+        shell: bash
+        env:
+          IS_PR: ${{ needs.configure.outputs.is-pr }}
+          JOB: ${{ matrix.os }}-${{ matrix.version }}
+        run: |
+          # Unit tests run on every job. Regression tests drive whole batch
+          # pipelines and are the only end-to-end coverage, so they run on every
+          # scheduled job; on PRs they run on one job only, to keep contributor
+          # feedback short. Both classes share a MATLAB session, so the fixed
+          # setup cost (checkout, test data, MATLAB install) is paid once, and
+          # both result sets are reported before the assert.
+          UNIT="u = spm_tests('class','unit','display',true);"
+          REGR="r = spm_tests('class','regression','display',true);"
+          if [ "$IS_PR" = "true" ] && [ "$JOB" != "ubuntu-latest-latest" ]; then
+            echo "command=addpath(pwd); $UNIT assert(all(~[u.Failed]));" >> $GITHUB_OUTPUT
+          else
+            echo "command=addpath(pwd); $UNIT $REGR assert(all(~[u.Failed]) && all(~[r.Failed]));" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run tests with existing MEX files (legacy)
+        if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
         uses: matlab-actions/run-command@v1
         with:
-          command: addpath(pwd); results = spm_tests('class','regression','display',true); assert(all(~[results.Failed]));
-      - name: Run unit tests with existing MEX files (legacy)
-        if: ${{github.event.schedule != '40 16 * * 3' && (matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b')}}
-        uses: matlab-actions/run-command@v1
-        with:
-          command: addpath(pwd); results = spm_tests('class','unit','display',true); assert(all(~[results.Failed]));
-      - name: Run regression tests with existing MEX files
-        if: ${{github.event.schedule == '40 16 * * 3' && matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
+          command: ${{ steps.classes.outputs.command }}
+      - name: Run tests with existing MEX files
+        if: ${{matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
         uses: matlab-actions/run-command@v2
         with:
-          command: addpath(pwd); results = spm_tests('class','regression','display',true); assert(all(~[results.Failed]));
-      - name: Run unit tests with existing MEX files
-        if: ${{github.event.schedule != '40 16 * * 3' && matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
-        uses: matlab-actions/run-command@v2
-        with:
-          command: addpath(pwd); results = spm_tests('class','unit','display',true); assert(all(~[results.Failed]));
+          command: ${{ steps.classes.outputs.command }}
 
       - name: Compile MEX files
         run: |

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -23,23 +23,27 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
-          # The reduced sweep is oldest-supported plus newest, which catches almost
-          # every regression within a day; the full sweep runs on the weekly cron,
-          # on releases and on manual dispatch. extra-os adds macos-26 (Apple
-          # Silicon) coverage for the releases that build there, and is empty on
-          # PRs so they keep the reduced matrix.
+          # Two tiers. Quick runs on pull requests and the daily cron: oldest
+          # supported plus newest release, which catches almost every regression
+          # within a day. Full runs on the weekly cron, on releases and on manual
+          # dispatch. extra-os adds macos-26 (Apple Silicon) coverage for the
+          # releases that build there.
           FULL='["R2020a","R2020b","R2021a","R2021b","R2022a","R2022b","R2023a","R2023b","R2024a","R2024b","R2025a","R2025b", "latest"]'
           REDUCED='["R2020a","latest"]'
+
+          # is-pr gates the test data checkout only: spm-tests-data is private and
+          # its token is not available to pull requests from forks. It does not
+          # affect which tests run.
           if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "is-pr=true" >> $GITHUB_OUTPUT
-            echo "versions=$REDUCED" >> $GITHUB_OUTPUT
-            echo 'extra-os=[]' >> $GITHUB_OUTPUT
-          elif [ "$EVENT_SCHEDULE" = "15 3 * * *" ]; then
+          else
             echo "is-pr=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_SCHEDULE" = "15 3 * * *" ]; then
             echo "versions=$REDUCED" >> $GITHUB_OUTPUT
             echo 'extra-os=[{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           else
-            echo "is-pr=false" >> $GITHUB_OUTPUT
             echo "versions=$FULL" >> $GITHUB_OUTPUT
             echo 'extra-os=[{"os":"macos-latest","version":"R2025b"},{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           fi
@@ -158,37 +162,18 @@ jobs:
         with:
           release: ${{matrix.version}}
 
-      - name: Select test classes
-        id: classes
-        shell: bash
-        env:
-          IS_PR: ${{ needs.configure.outputs.is-pr }}
-          JOB: ${{ matrix.os }}-${{ matrix.version }}
-        run: |
-          # Unit tests run on every job. Regression tests drive whole batch
-          # pipelines and are the only end-to-end coverage, so they run on every
-          # scheduled job; on PRs they run on one job only, to keep contributor
-          # feedback short. Both classes share a MATLAB session, so the fixed
-          # setup cost (checkout, test data, MATLAB install) is paid once, and
-          # both result sets are reported before the assert.
-          UNIT="u = spm_tests('class','unit','display',true);"
-          REGR="r = spm_tests('class','regression','display',true);"
-          if [ "$IS_PR" = "true" ] && [ "$JOB" != "ubuntu-latest-latest" ]; then
-            echo "command=addpath(pwd); $UNIT assert(all(~[u.Failed]));" >> $GITHUB_OUTPUT
-          else
-            echo "command=addpath(pwd); $UNIT $REGR assert(all(~[u.Failed]) && all(~[r.Failed]));" >> $GITHUB_OUTPUT
-          fi
-
+      # Every job runs both classes in one MATLAB session, so the fixed setup
+      # cost is paid once and both result sets are reported before the assert.
       - name: Run tests with existing MEX files (legacy)
         if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
         uses: matlab-actions/run-command@v1
         with:
-          command: ${{ steps.classes.outputs.command }}
+          command: addpath(pwd); u = spm_tests('class','unit','display',true); r = spm_tests('class','regression','display',true); assert(all(~[u.Failed]) && all(~[r.Failed]));
       - name: Run tests with existing MEX files
         if: ${{matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
         uses: matlab-actions/run-command@v2
         with:
-          command: ${{ steps.classes.outputs.command }}
+          command: addpath(pwd); u = spm_tests('class','unit','display',true); r = spm_tests('class','regression','display',true); assert(all(~[u.Failed]) && all(~[r.Failed]));
 
       - name: Compile MEX files
         run: |

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -22,8 +22,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # extra-os adds macos-26 (Apple Silicon) coverage for the releases that
-          # build there. Empty on PRs so they keep the reduced matrix.
+          # extra-os adds macos-26 (Apple Silicon) coverage for the releases that build there.
           if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "is-pr=true" >> $GITHUB_OUTPUT
             echo 'versions=["R2020a","latest"]' >> $GITHUB_OUTPUT
@@ -41,8 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{ fromJson(needs.configure.outputs.versions) }}
-        # macos-15-intel is Intel, macos-15 is Apple Silicon. Not macos-latest:
-        # its Xcode 26 linker breaks C++ MEX linking for MATLAB R2023b-R2025a.
+        # macos-15-intel is Intel, macos-15 is Apple Silicon. macos-latest is avoided
+        # because its Xcode 26 linker cannot link C++ MEX files for R2023b-R2025a.
         os: ["ubuntu-latest", "macos-15-intel", "macos-15", "windows-latest"]
         exclude:
           - os: windows-latest
@@ -71,7 +70,7 @@ jobs:
             version: "latest" # MATLAB dropped Intel Mac support starting with R2026a
         include: ${{ fromJson(needs.configure.outputs.extra-os) }}
     runs-on: ${{matrix.os}}
-    # A hung setup-matlab otherwise burns the 6h limit and cancels sibling jobs
+    # Stops a hung job exhausting the 6h workflow limit and cancelling its siblings.
     timeout-minutes: 120
     env:
       cache-key: tests-data2

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -15,6 +15,7 @@ jobs:
       versions: ${{ steps.config.outputs.versions }}
       is-pr: ${{ steps.config.outputs.is-pr }}
       extra-os: ${{ steps.config.outputs.extra-os }}
+      tier: ${{ steps.config.outputs.tier }}
     steps:
       - name: Determine test configuration
         id: config
@@ -41,9 +42,11 @@ jobs:
           fi
 
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_SCHEDULE" = "15 3 * * *" ]; then
+            echo "tier=quick" >> $GITHUB_OUTPUT
             echo "versions=$REDUCED" >> $GITHUB_OUTPUT
             echo 'extra-os=[{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           else
+            echo "tier=full" >> $GITHUB_OUTPUT
             echo "versions=$FULL" >> $GITHUB_OUTPUT
             echo 'extra-os=[{"os":"macos-latest","version":"R2025b"},{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           fi
@@ -162,18 +165,39 @@ jobs:
         with:
           release: ${{matrix.version}}
 
-      # Every job runs both classes in one MATLAB session, so the fixed setup
-      # cost is paid once and both result sets are reported before the assert.
+      - name: Select test classes
+        id: classes
+        shell: bash
+        env:
+          TIER: ${{ needs.configure.outputs.tier }}
+          OS: ${{ matrix.os }}
+        run: |
+          # Unit tests run on every job. Regression tests drive whole batch
+          # pipelines, and every regression failure seen so far reproduces
+          # identically on all platforms, so in the quick tier they run on
+          # ubuntu only. macOS is the long pole, so excluding it there is what
+          # keeps pull request feedback near 22 minutes instead of 39. The full
+          # tier still runs them everywhere. Both classes share one MATLAB
+          # session, so the fixed setup cost is paid once and both result sets
+          # are reported before the assert.
+          UNIT="u = spm_tests('class','unit','display',true);"
+          REGR="r = spm_tests('class','regression','display',true);"
+          if [ "$TIER" = "full" ] || [ "$OS" = "ubuntu-latest" ]; then
+            echo "command=addpath(pwd); $UNIT $REGR assert(all(~[u.Failed]) && all(~[r.Failed]));" >> $GITHUB_OUTPUT
+          else
+            echo "command=addpath(pwd); $UNIT assert(all(~[u.Failed]));" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run tests with existing MEX files (legacy)
         if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
         uses: matlab-actions/run-command@v1
         with:
-          command: addpath(pwd); u = spm_tests('class','unit','display',true); r = spm_tests('class','regression','display',true); assert(all(~[u.Failed]) && all(~[r.Failed]));
+          command: ${{ steps.classes.outputs.command }}
       - name: Run tests with existing MEX files
         if: ${{matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
         uses: matlab-actions/run-command@v2
         with:
-          command: addpath(pwd); u = spm_tests('class','unit','display',true); r = spm_tests('class','regression','display',true); assert(all(~[u.Failed]) && all(~[r.Failed]));
+          command: ${{ steps.classes.outputs.command }}
 
       - name: Compile MEX files
         run: |

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -36,7 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{ fromJson(needs.configure.outputs.versions) }}
-        os: ["ubuntu-latest", "macos-15-intel", "macos-latest", "windows-latest"] # macos-15-intel has Intel architecture, macos-latest has Apple Silicon
+        # macos-15-intel is Intel, macos-15 is Apple Silicon. Not macos-latest:
+        # its Xcode 26 linker breaks C++ MEX linking for MATLAB R2023b-R2025a.
+        os: ["ubuntu-latest", "macos-15-intel", "macos-15", "windows-latest"]
         exclude:
           - os: windows-latest
             version: "R2020a" # MATLAB not available
@@ -46,23 +48,31 @@ jobs:
             version: "R2021a" # Compiler not available
           - os: windows-latest
             version: "R2021b" # Compiler not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2020a" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2020b" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2021a" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2021b" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2022a" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2022b" # Apple Silicon version not available
-          - os: macos-latest
+          - os: macos-15
             version: "R2023a" # Apple Silicon version not available
           - os: macos-15-intel
             version: "latest" # MATLAB dropped Intel Mac support starting with R2026a
+        include:
+          # Keep macos-26 coverage for the releases that build there
+          - os: macos-latest
+            version: "R2025b"
+          - os: macos-latest
+            version: "latest"
     runs-on: ${{matrix.os}}
+    # A hung setup-matlab otherwise burns the 6h limit and cancels sibling jobs
+    timeout-minutes: 120
     env:
       cache-key: tests-data2
     steps:

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       versions: ${{ steps.config.outputs.versions }}
       is-pr: ${{ steps.config.outputs.is-pr }}
+      extra-os: ${{ steps.config.outputs.extra-os }}
     steps:
       - name: Determine test configuration
         id: config
@@ -21,12 +22,16 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          # extra-os adds macos-26 (Apple Silicon) coverage for the releases that
+          # build there. Empty on PRs so they keep the reduced matrix.
           if [ "$EVENT_NAME" = "pull_request" ]; then
             echo "is-pr=true" >> $GITHUB_OUTPUT
             echo 'versions=["R2020a","latest"]' >> $GITHUB_OUTPUT
+            echo 'extra-os=[]' >> $GITHUB_OUTPUT
           else
             echo "is-pr=false" >> $GITHUB_OUTPUT
             echo 'versions=["R2020a","R2020b","R2021a","R2021b","R2022a","R2022b","R2023a","R2023b","R2024a","R2024b","R2025a","R2025b", "latest"]' >> $GITHUB_OUTPUT
+            echo 'extra-os=[{"os":"macos-latest","version":"R2025b"},{"os":"macos-latest","version":"latest"}]' >> $GITHUB_OUTPUT
           fi
 
   matlab-tests:
@@ -64,12 +69,7 @@ jobs:
             version: "R2023a" # Apple Silicon version not available
           - os: macos-15-intel
             version: "latest" # MATLAB dropped Intel Mac support starting with R2026a
-        include:
-          # Keep macos-26 coverage for the releases that build there
-          - os: macos-latest
-            version: "R2025b"
-          - os: macos-latest
-            version: "latest"
+        include: ${{ fromJson(needs.configure.outputs.extra-os) }}
     runs-on: ${{matrix.os}}
     # A hung setup-matlab otherwise burns the 6h limit and cancels sibling jobs
     timeout-minutes: 120


### PR DESCRIPTION
## Why

Before #153, this workflow had three test configurations, driven by two independent conditionals (`is-pr` picked the version set, `github.event.schedule` picked the test class):

| | versions | class |
| --- | --- | --- |
| pull request | R2020a, latest | unit |
| daily cron | all 13 | unit |
| weekly cron | all 13 | regression |

That has two costs. The regression suite runs only on Wednesdays, so a regression can sit undetected for seven days. In practice it was worse: the Wednesday run was red for at least 12 consecutive weeks without being noticed. And because the class is what varies, the fixed per job cost is paid twice a week across the same matrix. Measured on R2024a, checkout plus the 376 MB test data cache, MATLAB install and MEX build come to roughly 4 minutes on ubuntu, 8 on Windows and 13 on macOS, before a single test runs.

Meanwhile the axis that actually drives wall clock is the MATLAB version count, not the test class. GitHub runs at most 5 macOS jobs concurrently, so in [run 32095672043](https://github.com/spm/spm/actions/runs/32095672043) the first five macOS jobs started at 03:29:45 and the eighteenth did not start until 04:27:40, 58 minutes later.

## What changed

Split by MATLAB version instead of by test class, and run both classes in one MATLAB session. Two tiers, not three:

| tier | triggers | versions | jobs | macOS jobs | unit | regression |
| --- | --- | --- | --- | --- | --- | --- |
| quick | pull request, daily cron | R2020a, latest | 6 | 3 | all 6 | 2 (ubuntu only) |
| full | weekly cron, release, dispatch | all 13 | 42 | 20 | all 42 | all 42 |

The quick tier fits inside the 5 slot macOS budget, so it no longer queues, and regression feedback drops from seven days to one. Pull requests and the daily cron run the identical matrix, so a green PR cannot become a red nightly.

The quick tier is 6 rather than 8 jobs because three combinations do not exist as MATLAB builds: R2020a has no Windows build (oldest there is R2022a) and no Apple Silicon build (oldest is R2023b), and `latest` has no Intel Mac build (MATLAB dropped Intel Mac at R2026a). The sixth job is the `extra-os` entry that keeps macos-26 Apple Silicon coverage.

Regression runs on ubuntu only in the quick tier. It adds roughly 11 minutes on ubuntu and 17 on macOS, and macOS is the long pole, so excluding it there takes pull request wall clock from about 39 minutes to about 22 and cuts compute per run by roughly a third. The saving is binary: any macOS job running regression keeps the wall clock at 39, so there is no useful middle ground.

`configure` now emits a `tier` output, so the class choice is expressed against coverage (tier plus OS) rather than against a cron string. `is-pr` survives only to gate the test data checkout, because `spm-tests-data` is private and its token is not available to pull requests from forks.

## Verification

The `configure` and `Select test classes` shell logic was executed directly, and the matrix expanded for every trigger:

| trigger | tier | jobs | regression on |
| --- | --- | --- | --- |
| `pull_request` | quick | 6 | 2, ubuntu-latest |
| daily cron | quick | 6 | 2, ubuntu-latest |
| weekly cron | full | 42 | 42, all five runners |
| `release`, `workflow_dispatch` | full | 42 | 42, all five runners |

## Notes for the reviewer

* This makes the regression suite a gate on every pull request. That only became safe with 97d3080ca, which fixed the `ft_hastoolbox('signal')` detection that made `test_regress_spm_meeg` fail with `Undefined function 'butter'` on every platform. Before that fix, merging this would have turned every pull request red.
* That fix currently lives in SPM's vendored `external/fieldtrip/`, which `sync-fieldtrip.yml` overwrites with `rsync --delete`. Until the equivalent change lands upstream, a FieldTrip sync will revert it and the regression suite will go red again. Worth keeping in mind when reviewing sync PRs.
* The trade for ubuntu-only regression in the quick tier is that platform specific end to end breakage is caught weekly rather than daily. That surface is narrow: the 212 unit tests still run on every platform in both tiers.
* In the quick tier, R2020a is only exercised on ubuntu and Intel Mac, since Windows and Apple Silicon have no build that old. Old release coverage on those two platforms is weekly either way.
* Both classes now share one MATLAB session. `spm_tests` builds a fresh `TestSuite` per call so this should be clean, but the first green run is what actually confirms no state leaks between classes.
* The full sweep runs both classes on 20 macOS jobs at 5 concurrent, roughly 39 minutes each, so about 2.5 hours wall clock. Comfortably inside the 6 hour workflow limit, and the per job `timeout-minutes: 120` leaves headroom.
* Windows regression time is extrapolated, not measured. Only ubuntu (11.1 min) and macOS Intel (16.9 min) were measured directly.
* Unchanged: the test data steps, the MEX build and artifact upload, and the `tests-passed` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
