### PR TITLE
Maintenance: pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
   # One grouped pull request per month for all action pins.
-  # The matlab-actions pins marked "kept for the older MATLAB releases" must stay
-  # on v1; Dependabot cannot express that, so reject those hunks when they appear.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -11,3 +9,9 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      # Some jobs pin matlab-actions to v1 for the older MATLAB releases.
+      # Dependabot cannot express that, so these are excluded entirely and
+      # reviewed by hand instead, roughly once a year.
+      - dependency-name: "matlab-actions/setup-matlab"
+      - dependency-name: "matlab-actions/run-command"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # One grouped pull request per month for all action pins.
+  # The matlab-actions pins marked "kept for the older MATLAB releases" must stay
+  # on v1; Dependabot cannot express that, so reject those hunks when they appear.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   # One grouped pull request per month for all action pins.
+  # The ignored actions below are reviewed by hand instead, roughly once a year.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -10,8 +11,10 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Some jobs pin matlab-actions to v1 for the older MATLAB releases.
-      # Dependabot cannot express that, so these are excluded entirely and
-      # reviewed by hand instead, roughly once a year.
+      # Pinned to v1 for the older MATLAB releases, which Dependabot cannot express.
       - dependency-name: "matlab-actions/setup-matlab"
       - dependency-name: "matlab-actions/run-command"
+      # Used only in release.yml, so no pull request exercises them and a bad
+      # version would first surface during a release.
+      - dependency-name: "peter-evans/repository-dispatch"
+      - dependency-name: "softprops/action-gh-release"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -54,16 +54,16 @@ jobs:
     
       - name: Set up MATLAB (legacy)
         if: ${{ matrix.matlab_legacy }}
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@e6b241a42928104e9e489fcc63aa2915df01565f # v1.2.5, kept for the older MATLAB releases
         with:
           release: ${{ matrix.matlab_release }}
       - name: Set up MATLAB
         if: ${{ !matrix.matlab_legacy }}
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: ${{ matrix.matlab_release }}
       - name: Checkout SPM
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Delete old MEX files on Ubuntu and Mac
         if: matrix.os != 'windows-latest'
@@ -83,7 +83,7 @@ jobs:
           # make -C src external-install
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-mex-${{ matrix.os_name }}
           path: ./**/*.${{ matrix.mex_ext }}
@@ -94,13 +94,13 @@ jobs:
     needs: compile_mex
     steps:
       - name: Download all MEX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: spm-mex-*
           merge-multiple: true
 
       - name: Upload all mex files as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-mex-all
           path: .

--- a/.github/workflows/install_test_standalone.yml
+++ b/.github/workflows/install_test_standalone.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Get latest commit for tests data
         id: checkout-tests-data
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
       
       - name: Try to retrieve commit from cache
         id: cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tests/data
           key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
@@ -62,7 +62,7 @@ jobs:
       - name: If cache missed, pull latest commit
         id: checkout-tests-data-lfs
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
@@ -71,13 +71,13 @@ jobs:
       
       - name: Cache latest commit
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tests/data
           key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
       
       - name: Upload test data as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-data
           path: tests/data
@@ -105,7 +105,7 @@ jobs:
           mv "$ASSET_NAME" "spm_standalone_${OS_NAME}.zip"
       
       - name: Upload as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-standalone-${{ matrix.os_name }}
           path: spm_standalone_${{ matrix.os_name }}.zip
@@ -131,10 +131,10 @@ jobs:
 
     steps:
       - name: Checkout SPM
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: latest
           products: |
@@ -142,7 +142,7 @@ jobs:
             Signal_Processing_Toolbox
 
       - name: Extract MATLAB version to file
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             fileID = fopen('matlab_release.txt', 'w');
@@ -164,7 +164,7 @@ jobs:
       # and mcc can bundle the shims into the standalone. Remove them again
       # before either runs.
       - name: Build MATLAB standalone
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             addpath(genpath('.'));
@@ -201,7 +201,7 @@ jobs:
 
       # Upload standalone as artifact
       - name: Upload standalone artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-standalone-${{ matrix.os_name }}
           path: spm_standalone_${{ matrix.os_name }}.zip
@@ -231,7 +231,7 @@ jobs:
 
     steps:
       - name: Download standalone artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: spm-standalone-${{ matrix.os_name }}
           path: .
@@ -321,7 +321,7 @@ jobs:
 
       # Download test data artifact (shared across all OS)
       - name: Download test data artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-data
           path: tests/data

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -102,12 +102,12 @@ jobs:
           echo "MW_MINGW64_LOC=C:\mingw64" >> $env:GITHUB_ENV
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get latest commit for tests data  # shallow fetch to get revision
         id: checkout-tests-data
         if: ${{ needs.configure.outputs.is-pr == 'false' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
@@ -120,7 +120,7 @@ jobs:
         run: rm -rf tests/data
       - name: Try to retrieve commit from cache
         id: cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tests/data
           key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
@@ -129,7 +129,7 @@ jobs:
       - name: If cache missed, pull latest commit...
         id: checkout-tests-data-lfs
         if: ${{ needs.configure.outputs.is-pr == 'false' && steps.cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
@@ -137,7 +137,7 @@ jobs:
           lfs: true
       - name: ... and cache latest commit
         if: ${{ needs.configure.outputs.is-pr == 'false' && steps.cache-restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: tests/data
           key: ${{ env.cache-key }}-${{ steps.checkout-tests-data.outputs.commit }}
@@ -152,12 +152,12 @@ jobs:
 
       - name: Set up MATLAB (legacy)
         if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@e6b241a42928104e9e489fcc63aa2915df01565f # v1.2.5, kept for the older MATLAB releases
         with:
           release: ${{matrix.version}}
       - name: Set up MATLAB
         if: ${{matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: ${{matrix.version}}
 
@@ -179,12 +179,12 @@ jobs:
 
       - name: Run tests with existing MEX files (legacy)
         if: ${{matrix.version == 'R2020a' || matrix.version == 'R2020b' || matrix.version == 'R2022a' || matrix.version == 'R2022b'}}
-        uses: matlab-actions/run-command@v1
+        uses: matlab-actions/run-command@c079d5cf746de09ffd5d8bd3cabcaf9161706e2b # v1.3.0, kept for the older MATLAB releases
         with:
           command: ${{ steps.classes.outputs.command }}
       - name: Run tests with existing MEX files
         if: ${{matrix.version != 'R2020a' && matrix.version != 'R2020b' && matrix.version != 'R2022a' && matrix.version != 'R2022b'}}
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: ${{ steps.classes.outputs.command }}
 
@@ -203,7 +203,7 @@ jobs:
         if: runner.os == 'Windows'
         run: echo "MEXEXT=$(mexext.bat)" >> $env:GITHUB_ENV
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-${{env.MEXEXT}}-${{runner.os}}-${{matrix.version}}
           path: ./**/*.${{env.MEXEXT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: Release SPM (code and MATLAB Standalone)
+
+# No pull request exercises this workflow, so repository-dispatch and
+# action-gh-release are excluded from Dependabot. Check them before a release.
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set up MATLAB
         id: setup_matlab
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: ${{matrix.version}}
           products: |
@@ -68,7 +68,7 @@ jobs:
             Signal_Processing_Toolbox
 
       - name: Extract MATLAB version to file
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             fileID = fopen('matlab_release.txt', 'w')
@@ -85,7 +85,7 @@ jobs:
           echo "MATLAB_VERSION=$matlab_release" >> $GITHUB_ENV
 
       - name: Checkout SPM
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Delete hidden files and folders
         shell: bash
@@ -118,7 +118,7 @@ jobs:
       # and mcc can bundle the shims into the standalone. Remove them again
       # before either runs.
       - name: Build MATLAB standalone
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             addpath(genpath('.'));
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload Raw Compilation Artifact
         if: github.event_name == 'workflow_dispatch' && runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: raw_compilation_${{ matrix.os_name }}
           path: raw_compilation_debug/
@@ -250,7 +250,7 @@ jobs:
           fi
 
       - name: Release standalone
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ env.BUILD_TAG }} # Required for dispatch events (refs/heads/main -> dev)
           prerelease: ${{ env.PRERELEASE }}
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload Artifact (Dev/Test)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm_standalone_${{ env.BUILD_TAG }}_${{ matrix.os_name }}_${{ matrix.version }}
           # Path must be within workspace, ../ is not allowed
@@ -278,7 +278,7 @@ jobs:
 
       - name: Release SPM
         if: runner.os == 'Linux' && matrix.version == 'latest' && github.event_name != 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           prerelease: ${{ env.PRERELEASE }}
           files: ../spm_${{ env.BUILD_TAG }}.zip
@@ -293,7 +293,7 @@ jobs:
 
       - name: Trigger workflow in spm-docker
         if: env.PRERELEASE == 'false' && runner.os == 'Linux' && matrix.version == 'latest' && github.event_name != 'workflow_dispatch'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.PAT_TOKEN_SPM_DOCKER }}
           repository: spm/spm-docker

--- a/.github/workflows/sync-fieldtrip.yml
+++ b/.github/workflows/sync-fieldtrip.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out SPM repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # fetch-depth: 0 (full history) is required by
           # peter-evans/create-pull-request to correctly find the common
@@ -142,7 +142,7 @@ jobs:
         if: >
           steps.check-update.outputs.skip == 'false' &&
           steps.diff-check.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7 (hash for safety, since we use a PAT_TOKEN)
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           # PAT_FIELDTRIP_SYNC needs "Contents: Read and write + Pull requests: Read and write".
           # Using a PAT (not GITHUB_TOKEN) is required so that the created PR triggers the testing workflow.

--- a/.github/workflows/test_container.yml
+++ b/.github/workflows/test_container.yml
@@ -62,10 +62,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout SPM
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: latest
           products: |
@@ -73,7 +73,7 @@ jobs:
             Signal_Processing_Toolbox
 
       - name: Extract MATLAB version to file
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             fileID = fopen('matlab_release.txt', 'w');
@@ -91,7 +91,7 @@ jobs:
       # and mcc can bundle the shims into the standalone. Remove them again
       # before either runs.
       - name: Build MATLAB standalone
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         with:
           command: |
             addpath(genpath('.'));
@@ -115,7 +115,7 @@ jobs:
           unzip -l spm/spm_standalone_Linux.zip | head -20
 
       - name: Upload standalone artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spm-standalone-Linux
           path: spm_standalone_Linux.zip
@@ -139,7 +139,7 @@ jobs:
       # out. The repository is an input so that changes to the recipe can be
       # tried from a fork before they are merged.
       - name: Checkout container recipe from spm-docker
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.spm_docker_repo || 'spm/spm-docker' }}
           ref: ${{ inputs.spm_docker_ref || 'main' }}
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Download standalone artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: spm-standalone-Linux
           path: spm-docker
@@ -181,7 +181,7 @@ jobs:
 
       - name: Checkout test data
         if: steps.data_access.outputs.available == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spm/spm-tests-data
           token: ${{ secrets.TESTS_DATA_REPO_TOKEN }}
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-test-logs
           path: |


### PR DESCRIPTION
Supersedes #139, which proposed the same idea but mapped both `matlab-actions/setup-matlab@v1` and `@v2` to the same SHA, silently upgrading the legacy jobs to v2.7.0. See the note at the end.

## Why

Every action reference floated on a major tag. That absorbs patches silently but never crosses a major, so the repo drifted:

| action | was | now |
| --- | --- | --- |
| `actions/download-artifact` | v4 | **v8.0.1** |
| `actions/checkout` | v4 | **v7.0.1** |
| `actions/upload-artifact` | v4 | **v7.0.1** |
| `actions/cache` | v4 | **v6.1.0** |
| `matlab-actions/setup-matlab` | v2 | **v3.0.2** |
| `matlab-actions/run-command` | v2 | **v3.2.1** |
| `softprops/action-gh-release` | v2 | **v3.0.2** |
| `peter-evans/repository-dispatch` | v3 | **v4.0.1** |
| `peter-evans/create-pull-request` | v7 | **v8.1.1** |
| `contributor-assistant/github-action` | v2.6.1 | v2.6.1, already current |

The Node 20 deprecation warnings in the workflow logs are this bill coming due. The v4 actions target a runtime GitHub is removing, and when it goes they break together.

Tags are also mutable. A compromised action repository can repoint one at malicious code, which is how CVE-2025-30066 reached roughly 23000 repositories in March 2025: every version tag was moved, so pinning `@v44.5.1` gave no protection and only SHA pins were unaffected. `sync-fieldtrip.yml` already pinned `create-pull-request` by SHA with the comment "hash for safety, since we use a PAT_TOKEN", so this extends practice the repo had already adopted for its highest risk case.

## What changed

50 references across all 7 workflows, each pinned to a SHA with the version in a trailing comment so the file stays readable:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

`matlab-actions` stays on v1 where the older MATLAB releases need it, pinned separately from the v3 references:

```yaml
uses: matlab-actions/setup-matlab@e6b241a42928104e9e489fcc63aa2915df01565f # v1.2.5, kept for the older MATLAB releases
uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
```

`.github/dependabot.yml` adds one grouped pull request per month. Pinning without it would be a downgrade: the repo would freeze on this snapshot and stop receiving security patches entirely.

Four actions are excluded from Dependabot and reviewed by hand instead, roughly once a year:

| excluded | why |
| --- | --- |
| `matlab-actions/setup-matlab`, `matlab-actions/run-command` | Dependabot treats an action as one dependency, so it cannot leave the v1 pins alone while updating the v3 ones. Every monthly pull request would carry a hunk needing a judgement call, which is the kind of review that eventually gets rubber stamped. |
| `peter-evans/repository-dispatch`, `softprops/action-gh-release` | used only in `release.yml`, which no pull request triggers, so a green run says nothing about them and a bad version would first surface during a release. |

What remains should merge without thought, which is the point. Of the six actions Dependabot still manages, four are exercised directly by a pull request; the other two, `actions/download-artifact` and `peter-evans/create-pull-request`, are exercised daily by `test_container.yml` and `sync-fieldtrip.yml`, so a bad version shows up within a day rather than at a release.

## Breaking changes checked

Almost every major crossed is a Node 20 to Node 24 runtime move with no behavioural change. The three that were not:

* **`download-artifact` v5** changed path handling for downloads **by ID**. This repo downloads by `name` and `pattern` only, so it is unaffected.
* **`checkout` v7** blocks fork PR checkout under `pull_request_target` and `workflow_run`. The only `pull_request_target` workflow is `cla.yml`, which checks out nothing.
* **`upload-artifact` v7** adds an opt-in `archive: false` for direct uploads; the default is unchanged.

All twelve SHAs were resolved against the official repositories and confirmed to carry the stated release tag.

## Note on #139

#139 proposed the same pinning, but mapped both `matlab-actions/setup-matlab@v1` and `@v2` to `aa8bbc7b…`, which is tagged v2.7.0. Real `v1` is `e6b241a4…`. That would have silently moved the four legacy jobs to v2, and since `setup-matlab@v1` on Linux installs a broader product set than v2, those are exactly the jobs whose toolbox availability differs. #139 also omitted version comments. Worth closing with thanks, since the underlying finding was sound.

The companion PRs #140, #141 and #142 replace long-lived PATs with GitHub App tokens. That idea is good, but they reference `vars.APP_ID` and `secrets.APP_PRIVATE_KEY`, neither of which exists in this repository, and the token step carries no `if:` guard while the step it feeds does. They need the App created first and the guards fixed, so they are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


