### PR TITLE
Fix free-energy log-det term overcounted by factor nq in spm_nlsi_GN

### DIFF
--- a/spm_nlsi_GN.m
+++ b/spm_nlsi_GN.m
@@ -497,7 +497,7 @@ for k = 1:M.Nmax
     
     % objective function: F(p) = log evidence - divergence
     %----------------------------------------------------------------------
-    L(1) = spm_logdet(iS)*nq/2  - real(e'*iS*e)/2 - ny*log(8*atan(1))/2;
+    L(1) = spm_logdet(iS)/2     - real(e'*iS*e)/2 - ny*log(8*atan(1))/2;
     L(2) = spm_logdet(ipC*Cp)/2 - p'*ipC*p/2;
     L(3) = spm_logdet(ihC*Ch)/2 - d'*ihC*d/2;
     F    = sum(L);


### PR DESCRIPTION
Fixes #160 .

`L(1)` computed the log-evidence log-det as `spm_logdet(iS)*nq/2`, but `iS`
is already the Kronecker-expanded ny×ny precision at that point, so
`spm_logdet(iS)` already carries the nq factor and the term was scaled by
nq² rather than nq. Corrected to `spm_logdet(iS)/2`, which matches the
M-step gradient (`ny/2` / `trace(PS)*nq/2`) that ascends this objective.

Only affects models with more than one error-covariance component (nq > 1,
e.g. DCM for ERP/induced responses), where it changes the free energy and
thus model comparison; nq == 1 (fMRI DCM) is unchanged.