### PR TITLE
Fix baseline double-counting when mapping artefact events to samples

### DIFF
--- a/@meeg/badsamples.m
+++ b/@meeg/badsamples.m
@@ -36,8 +36,8 @@ for i = 1:length(trialind)
             find(cellfun(@ischar, {ev.value}))));
         for k = 1:numel(ev)
             [dum, chan] = intersect(chanind, selectchannels(this, ev(k).value));
-            samples     = find((trialonset(this, trialind(i))+time(this))>=ev(k).time & ...
-                (trialonset(this, trialind(i))+time(this))<=(ev(k).time+ev(k).duration));
+            samples     = find((trialonset(this, trialind(i))+(0:nsamples(this)-1)./fsample(this))>=ev(k).time & ...
+                (trialonset(this, trialind(i))+(0:nsamples(this)-1)./fsample(this))<=(ev(k).time+ev(k).duration));
             res(chan, samples, i) = true;
         end
     end


### PR DESCRIPTION
Fixes #162.

`badsamples` added `trialonset + time(this)`, but `time(this)` already includes the peristimulus `timeOnset`, whereas detector event times are stored relative to trial onset without it. The onset offset was counted twice, shifting every bad-sample window by the baseline length (`timeOnset*fs` samples) on epoched data.

This uses the trial-relative offset `(0:nsamples-1)/fsample` instead of `time(this)`. Behaviour is identical when `timeOnset == 0` (continuous data, or epochs with no baseline); the spurious shift is removed otherwise.