### PR TITLE
Stamp downsampled dataset with achieved, not requested, sampling rate

### DIFF
--- a/spm_eeg_downsample.m
+++ b/spm_eeg_downsample.m
@@ -112,7 +112,7 @@ spm_progress_bar('Clear');
 
 %-Save new downsampled M/EEG dataset
 %--------------------------------------------------------------------------
-Dnew = fsample(Dnew, S.fsample_new);
+Dnew = fsample(Dnew, fsample_new);
 D    = Dnew;
 D    = D.history('spm_eeg_downsample', S);
 save(D);


### PR DESCRIPTION
Fixes #164 .

`spm_eeg_downsample` stored `S.fsample_new` (the requested rate) on the output object, but `ft_preproc_resample` rounds the decimation factor, so the achieved rate — already computed as `fsample_new` and used for the on-screen report — can differ. For non-integer ratios the stored rate was silently wrong (e.g. requested 180 Hz, actual ~166.7 Hz), biasing all downstream latencies and filters. This stores the computed `fsample_new` so the stamped rate matches the data.