### PR TITLE
Maintenance: build Linux MEX files inside a manylinux2014 container

### DIFF
--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -100,7 +100,7 @@ jobs:
           docker run --rm \
             -v "$MATLAB_ROOT":"$MATLAB_ROOT":ro \
             -v "$PWD":"$PWD" -w "$PWD" \
-            -e MATLAB_ROOT \
+            -e MATLAB_ROOT="$MATLAB_ROOT" \
             ${{ matrix.container }} bash -euo pipefail -c '
               export PATH="$MATLAB_ROOT/bin:$PATH"
               gcc --version | head -n 1

--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -18,12 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # On Linux, the OS version should be as old as possible for mex compatibility.
+          # On Linux the glibc floor of a MEX file is set by the build host, and
+          # ubuntu-22.04 (glibc 2.35) is the oldest runner available. MEX files built
+          # on it need GLIBC_2.29, which excludes RHEL 8 (glibc 2.28), a platform
+          # MATLAB supports. The compile therefore runs inside a manylinux2014
+          # container (CentOS 7, glibc 2.17). MATLAB is installed on the runner as
+          # before and bind-mounted into the container.
           - os: ubuntu-22.04
             os_name: Linux
             mex_ext: mexa64
             matlab_release: R2020a
             matlab_legacy: true
+            container: quay.io/pypa/manylinux2014_x86_64
           # On Mac and Windows the Matlab version drives mex compatibility, but macos-latest
           # is avoided because its Xcode 26 linker cannot link C++ MEX files for R2023b.
           - os: macos-15-intel
@@ -74,6 +80,7 @@ jobs:
         run: Get-ChildItem -Path .\ -Recurse -Include *.mex* | Remove-Item -Force
 
       - name: Compile MEX files
+        if: ${{ !matrix.container }}
         run: |
           make -C src distclean
           make -C src
@@ -81,6 +88,47 @@ jobs:
           # make -C src external-distclean # on windows there is an issue with fieldtrip
           # make -C src external
           # make -C src external-install
+
+      - name: Compile MEX files in ${{ matrix.container }}
+        if: ${{ matrix.container }}
+        run: |
+          # `matlab -e` prints the launcher environment without starting MATLAB.
+          MATLAB_ROOT="$(matlab -e 2>/dev/null | sed -n 's/^MATLAB=//p')"
+          [ -n "$MATLAB_ROOT" ] || MATLAB_ROOT="$(dirname "$(dirname "$(readlink -f "$(command -v mex)")")")"
+          echo "MATLAB root: $MATLAB_ROOT"
+          # Both trees are mounted at their host paths so nothing needs relocating.
+          docker run --rm \
+            -v "$MATLAB_ROOT":"$MATLAB_ROOT":ro \
+            -v "$PWD":"$PWD" -w "$PWD" \
+            -e MATLAB_ROOT \
+            ${{ matrix.container }} bash -euo pipefail -c '
+              export PATH="$MATLAB_ROOT/bin:$PATH"
+              gcc --version | head -n 1
+              make -C src distclean
+              make -C src
+              make -C src install
+            '
+          sudo chown -R "$(id -u):$(id -g)" .
+
+      - name: Check the glibc floor
+        if: ${{ matrix.container }}
+        run: |
+          # Nothing built inside the container can need more than its own glibc and
+          # libstdc++, so a higher floor means the container was bypassed.
+          versions=$(find . -name '*.${{ matrix.mex_ext }}' -not -path './external/*' \
+                       -exec objdump -T {} \; | grep -oE 'GLIBC(XX)?_[0-9.]+' | sort -uV || true)
+          glibc=$(echo "$versions" | grep '^GLIBC_' | tail -n 1 || true)
+          glibcxx=$(echo "$versions" | grep '^GLIBCXX_' | tail -n 1 || true)
+          echo "**Linux MEX floor:** \`${glibc:-none}\`, libstdc++ \`${glibcxx:-none}\`" >> "$GITHUB_STEP_SUMMARY"
+          check() {
+            [ -z "$1" ] && return 0
+            if [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -n 1)" != "$2" ]; then
+              echo "::error::MEX files require $1, above the $2 floor of ${{ matrix.container }}"
+              exit 1
+            fi
+          }
+          check "$glibc" GLIBC_2.17
+          check "$glibcxx" GLIBCXX_3.4.19
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile_mex.yml
+++ b/.github/workflows/compile_mex.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # On Linux the glibc floor of a MEX file is set by the build host, and
-          # ubuntu-22.04 (glibc 2.35) is the oldest runner available. MEX files built
-          # on it need GLIBC_2.29, which excludes RHEL 8 (glibc 2.28), a platform
+          # On Linux the glibc floor of a MEX file is set by the build host, and every
+          # available runner is too new: even ubuntu-22.04 (glibc 2.35) yields MEX
+          # files needing GLIBC_2.29, which excludes RHEL 8 (glibc 2.28), a platform
           # MATLAB supports. The compile therefore runs inside a manylinux2014
-          # container (CentOS 7, glibc 2.17). MATLAB is installed on the runner as
-          # before and bind-mounted into the container.
-          - os: ubuntu-22.04
+          # container (CentOS 7, glibc 2.17), which makes the runner image irrelevant
+          # to the result. MATLAB is installed on the runner and bind-mounted in.
+          - os: ubuntu-latest
             os_name: Linux
             mex_ext: mexa64
             matlab_release: R2020a


### PR DESCRIPTION
## Summary

The Linux job of `compile_mex.yml` now runs `make -C src` inside a `manylinux2014` container (CentOS 7, glibc 2.17) instead of directly on the runner. MATLAB is still installed on the runner by `setup-matlab` and is bind-mounted into the container, so nothing else about the build changes. Because the host image no longer influences the result, the job's runner moves from `ubuntu-22.04` to `ubuntu-latest`. A new step reports the glibc and libstdc++ floor of the built MEX files in the job summary and fails the job if it exceeds what the container can produce.

## Why

The glibc floor of a MEX file is set by the host it is built on. `ubuntu-22.04` is the oldest runner GitHub offers, and its MEX files need `GLIBC_2.29` because glibc 2.29 re-versioned `exp`, `log` and `pow`, which 11 of the 51 sources in `src/` call. MathWorks' documented Linux minimum is glibc 2.28 with RHEL 8.6 still supported ([system requirements](https://www.mathworks.com/support/requirements/matlab-linux.html)), so the workflow's output could not load on RHEL, Rocky or Alma 8.

Measured by building a small C and C++ shared object in each image:

| Build host | glibc floor | libstdc++ floor |
|---|---|---|
| ubuntu-22.04 (gcc 11) | GLIBC_2.29 | GLIBCXX_3.4.21 |
| ubuntu-24.04 (gcc 13) | GLIBC_2.29 | GLIBCXX_3.4.32 |
| manylinux2014 (gcc 10, devtoolset) | GLIBC_2.2.5 | GLIBCXX_3.4.11 |
| committed `*.mexa64` files | GLIBC_2.14 | GLIBCXX_3.4.18 |

The `ubuntu-24.04` row matters because the `ubuntu-22.04` image starts deprecation on 17 September 2026 and is removed on 17 April 2027 ([actions/runner-images#14254](https://github.com/actions/runner-images/issues/14254)). On 24.04 the two C++ MEX files (`spm_mesh_dist`, `spm_mesh_geodesic`) would need `GLIBCXX_3.4.32`, which the libstdc++ bundled with MATLAB does not provide, so they would fail to load in most MATLAB releases. With the container the floor no longer depends on which runner GitHub still provides.

## Why `docker run` rather than a job-level `container:`

`setup-matlab@v1` installs its dependencies with apt and has to run on the Ubuntu host, and GitHub's Node runtime needs glibc 2.28 or newer, which rules out manylinux2014 as a job container. Running only the compile in the container, with MATLAB and the checkout mounted at their host paths, keeps the rest of the job as it was.

## Verification

Verified on [run 33616233368](https://github.com/spm/spm/actions/runs/33616233368) of this branch, with the host on `ubuntu-latest` (currently Ubuntu 24.04). The Linux job resolved the MATLAB root via `matlab -e`, built all 67 MEX targets inside the container with gcc 10.2.1 from its devtoolset, and the resulting files need `GLIBC_2.14` and `GLIBCXX_3.4.18`, the same floor as the committed `*.mexa64` files. The check step passed. An earlier run on an `ubuntu-22.04` host ([33615158620](https://github.com/spm/spm/actions/runs/33615158620)) produced the identical floor, which is the point: the host no longer matters. The macOS and Windows jobs are not touched by this change.

## Follow-up

- If `matlab_release` for Linux is ever raised to R2024a or newer, MATLAB itself needs glibc 2.28 and the container should become `manylinux_2_28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
