### PR TITLE
Account for basis functions when padding parametric-modulation columns

### DIFF
--- a/spm_design_contrasts.m
+++ b/spm_design_contrasts.m
@@ -60,7 +60,7 @@ if isfield(SPM,'Sess')
         block = [];
         for cc=1:conds
             block = [block,con(c).c(:,col:col+nbases-1)];
-            block = [block,zeros(nr,sum([SPM.Sess(1).U(cc).P.h]))];
+            block = [block,zeros(nr,sum([SPM.Sess(1).U(cc).P.h])*nbases)];
             col   = col + nbases;
         end
         con(c).c  = block;


### PR DESCRIPTION
Fixes #167 .

`spm_design_contrasts` padded automatic factorial contrasts with `sum(h)` zero columns for parametric modulators, but each modulator column is convolved with all `nbases` basis functions in the design, so a condition spans `(1+sum(h))*nbases` columns. The under-padding shifted subsequent conditions' weights onto the wrong regressors whenever `nbases > 1` and modulators were present, producing silently wrong F/T maps (the trailing zero-pad hid the mismatch).

This multiplies the modulation pad width by `nbases`. No change when `nbases == 1` or when there are no parametric modulators.